### PR TITLE
refactor: dependency-injected persistence and route composition

### DIFF
--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	systemAPI "github.com/go-admin-kit/server/internal/api/system"
 	"github.com/go-admin-kit/server/internal/config"
+	authDAO "github.com/go-admin-kit/server/internal/dao/auth"
 	"github.com/go-admin-kit/server/internal/middleware"
 	"github.com/go-admin-kit/server/internal/pkg/authz"
 	"github.com/go-admin-kit/server/internal/pkg/database"
@@ -27,6 +28,7 @@ import (
 	"github.com/go-admin-kit/server/internal/pkg/observability"
 	"github.com/go-admin-kit/server/internal/pkg/redis"
 	"github.com/go-admin-kit/server/internal/pkg/runtimeconfig"
+	authsvc "github.com/go-admin-kit/server/internal/service/auth"
 	monitorSvc "github.com/go-admin-kit/server/internal/service/monitor"
 	systemSvc "github.com/go-admin-kit/server/internal/service/system"
 )
@@ -251,6 +253,11 @@ func run(ctx context.Context) error {
 	if err := authz.RegisterDataScopePlugin(database.DB); err != nil {
 		return fmt.Errorf("data scope plugin registration failed: %w", err)
 	}
+	middleware.SetAuthMiddlewareDependencies(middleware.AuthMiddlewareDependencies{
+		Users:           authDAO.NewUserDAO(database.DB),
+		Permissions:     authDAO.NewPermissionDAO(database.DB),
+		ConsoleSessions: authsvc.NewConsoleSessionServiceWithDB(database.DB),
+	})
 	defer func() {
 		if err := database.Close(); err != nil {
 			logger.Error("database close failed", logger.Err(err))

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -258,6 +258,11 @@ func run(ctx context.Context) error {
 		Permissions:     authDAO.NewPermissionDAO(database.DB),
 		ConsoleSessions: authsvc.NewConsoleSessionServiceWithDB(database.DB),
 	})
+	authz.SetPersistence(authz.Persistence{
+		Users:       authDAO.NewUserDAO(database.DB),
+		Permissions: authDAO.NewPermissionDAO(database.DB),
+		DataScope:   authz.NewDatabaseDataScopeStore(database.DB),
+	})
 	defer func() {
 		if err := database.Close(); err != nil {
 			logger.Error("database close failed", logger.Err(err))

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/go-admin-kit/server/internal/api"
+	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	systemAPI "github.com/go-admin-kit/server/internal/api/system"
 	"github.com/go-admin-kit/server/internal/config"
 	"github.com/go-admin-kit/server/internal/middleware"
@@ -358,8 +359,8 @@ func run(ctx context.Context) error {
 	router.Use(middleware.RequestLogger())
 	router.Use(middleware.ErrorHandler())
 	setupCORS(router)
-	api.SetupRoutes(router)
-	jobScheduler := monitorSvc.GetJobService()
+	jobScheduler := monitorSvc.InitJobService(database.DB)
+	api.SetupRoutesWithDeps(router, sharedapi.Dependencies{DB: database.DB, Redis: redis.Client})
 	defer func() {
 		if err := shutdownJobScheduler(jobScheduler, 5*time.Second); err != nil {
 			logger.Warn("job scheduler shutdown timeout", logger.Err(err))

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -266,7 +266,8 @@ func run(ctx context.Context) error {
 
 	lifecycleCtx, cancelLifecycle := context.WithCancel(ctx)
 	defer cancelLifecycle()
-	operationLogDone := middleware.StartOperationLogProcessor(lifecycleCtx)
+	operationLogService := systemSvc.NewOperationLogServiceWithDB(database.DB)
+	operationLogDone := middleware.StartOperationLogProcessor(lifecycleCtx, &operationLogService)
 	defer func() {
 		if err := stopOperationLogProcessor(cancelLifecycle, operationLogDone, 5*time.Second); err != nil {
 			logger.Warn("operation log processor shutdown timeout", logger.Err(err))

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	systemAPI "github.com/go-admin-kit/server/internal/api/system"
 	"github.com/go-admin-kit/server/internal/config"
 	authDAO "github.com/go-admin-kit/server/internal/dao/auth"
+	systemDAO "github.com/go-admin-kit/server/internal/dao/system"
 	"github.com/go-admin-kit/server/internal/middleware"
 	"github.com/go-admin-kit/server/internal/pkg/authz"
 	"github.com/go-admin-kit/server/internal/pkg/database"
@@ -263,6 +264,7 @@ func run(ctx context.Context) error {
 		Permissions: authDAO.NewPermissionDAO(database.DB),
 		DataScope:   authz.NewDatabaseDataScopeStore(database.DB),
 	})
+	runtimeconfig.SetSecurityPolicyStore(systemDAO.NewSettingDAO(database.DB))
 	defer func() {
 		if err := database.Close(); err != nil {
 			logger.Error("database close failed", logger.Err(err))

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -281,7 +281,7 @@ func run(ctx context.Context) error {
 		}
 	}()
 
-	if menuResult, err := systemSvc.BootstrapDefaultMenusContext(ctx); err != nil {
+	if menuResult, err := systemSvc.BootstrapDefaultMenusContext(ctx, database.DB); err != nil {
 		return fmt.Errorf("default menu bootstrap failed: %w", err)
 	} else if menuResult.Menus > 0 {
 		logger.Info("default menus bootstrapped", logger.Int("menus", menuResult.Menus))

--- a/server/internal/api/auth/console_compat.go
+++ b/server/internal/api/auth/console_compat.go
@@ -91,7 +91,7 @@ func (a *UserAPI) writeConsoleLoginSession(c *gin.Context, loginResp *authSvc.Lo
 		return
 	}
 
-	permissions := authSvc.ConsolePermissionsForUser(c.Request.Context(), &loginResp.User, a.userService.GetUserPermissions(&loginResp.User))
+	permissions := authSvc.ConsolePermissionsForUser(c.Request.Context(), a.consoleRouteService, &loginResp.User, a.userService.GetUserPermissions(&loginResp.User))
 	session := authSvc.BuildConsoleSession(c.Request.Context(), &loginResp.User, permissions, loginResp.AccessToken, loginResp.RefreshToken)
 	setConsoleSessionCookie(c, loginResp.AccessToken, session.TTLSec)
 	a.recordOnlineUser(c, loginResp.AccessToken)
@@ -121,7 +121,7 @@ func (a *UserAPI) GetConsoleSession(c *gin.Context) {
 	}
 
 	token := consoleauth.TokenFromGinContext(c)
-	permissions := authSvc.ConsolePermissionsForUser(c.Request.Context(), user, a.userService.GetUserPermissions(user))
+	permissions := authSvc.ConsolePermissionsForUser(c.Request.Context(), a.consoleRouteService, user, a.userService.GetUserPermissions(user))
 	response.Success(c, authSvc.BuildConsoleSession(c.Request.Context(), user, permissions, token, ""))
 }
 
@@ -138,7 +138,7 @@ func (a *UserAPI) GetConsoleRoutes(c *gin.Context) {
 		return
 	}
 
-	permissions := authSvc.ConsolePermissionsForUser(c.Request.Context(), user, a.userService.GetUserPermissions(user))
+	permissions := authSvc.ConsolePermissionsForUser(c.Request.Context(), a.consoleRouteService, user, a.userService.GetUserPermissions(user))
 	roles := authSvc.ConsoleRoleCodes(user.Roles)
 	routes, err := a.consoleRouteService.ListAccessibleRoutesContext(c.Request.Context(), permissions, roles)
 	if err != nil {

--- a/server/internal/api/auth/menu.go
+++ b/server/internal/api/auth/menu.go
@@ -18,6 +18,11 @@ func NewMenuAPI() *MenuAPI {
 	}
 }
 
+// NewMenuAPIWithService creates a MenuAPI instance from an injected service.
+func NewMenuAPIWithService(menuUserService system.MenuUserService) *MenuAPI {
+	return &MenuAPI{menuUserService: menuUserService}
+}
+
 // GetUserMenus returns the authenticated user's menu tree.
 func (a *MenuAPI) GetUserMenus(c *gin.Context) {
 	userID, exists := c.Get("user_id")

--- a/server/internal/api/auth/oauth.go
+++ b/server/internal/api/auth/oauth.go
@@ -30,6 +30,11 @@ func NewOAuthAPI() *OAuthAPI {
 	}
 }
 
+// NewOAuthAPIWithService creates an OAuthAPI instance from an injected service.
+func NewOAuthAPIWithService(service *authsvc.OAuthService) *OAuthAPI {
+	return &OAuthAPI{oauthService: service}
+}
+
 // GithubLogin redirects to GitHub OAuth.
 func (a *OAuthAPI) GithubLogin(c *gin.Context) {
 	url, err := a.oauthService.GetGithubAuthURLContext(c.Request.Context())

--- a/server/internal/api/auth/routes.go
+++ b/server/internal/api/auth/routes.go
@@ -2,11 +2,19 @@ package auth
 
 import (
 	"github.com/gin-gonic/gin"
+	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	"github.com/go-admin-kit/server/internal/middleware"
 )
 
-// RegisterPublicRoutes mounts unauthenticated authentication routes.
+// RegisterPublicRoutes mounts unauthenticated authentication routes using
+// legacy global fallbacks.
 func RegisterPublicRoutes(r gin.IRoutes) {
+	RegisterPublicRoutesWithDeps(r, sharedapi.Dependencies{})
+}
+
+// RegisterPublicRoutesWithDeps mounts unauthenticated authentication routes
+// with injected infrastructure handles.
+func RegisterPublicRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies) {
 	userAPI := NewUserAPI()
 	r.POST("/login", userAPI.Login)
 	r.POST("/login/2fa/verify", userAPI.VerifyTOTPLogin)
@@ -26,8 +34,15 @@ func RegisterPublicRoutes(r gin.IRoutes) {
 	r.GET("/oauth/wechat/callback", oauthAPI.WechatCallback)
 }
 
-// RegisterProtectedRoutes mounts authenticated console/user authentication routes.
+// RegisterProtectedRoutes mounts authenticated console/user authentication
+// routes using legacy global fallbacks.
 func RegisterProtectedRoutes(r gin.IRoutes) {
+	RegisterProtectedRoutesWithDeps(r, sharedapi.Dependencies{})
+}
+
+// RegisterProtectedRoutesWithDeps mounts authenticated console/user
+// authentication routes with injected infrastructure handles.
+func RegisterProtectedRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies) {
 	userAPI := NewUserAPI()
 	r.GET("/auth/me", userAPI.GetConsoleSession)
 	r.GET("/auth/routes", userAPI.GetConsoleRoutes)

--- a/server/internal/api/auth/routes.go
+++ b/server/internal/api/auth/routes.go
@@ -4,7 +4,42 @@ import (
 	"github.com/gin-gonic/gin"
 	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	"github.com/go-admin-kit/server/internal/middleware"
+	authsvc "github.com/go-admin-kit/server/internal/service/auth"
+	systemsvc "github.com/go-admin-kit/server/internal/service/system"
 )
+
+// newUserAPIFromDeps assembles a UserAPI from injected handles, falling back
+// to the legacy zero-value wiring when no database handle is provided.
+func newUserAPIFromDeps(deps sharedapi.Dependencies) *UserAPI {
+	if deps.DB == nil {
+		return NewUserAPI()
+	}
+	var onlineUserService onlineUserRecorder = &systemsvc.OnlineUserService{}
+	if deps.Redis != nil {
+		onlineUserService = systemsvc.NewOnlineUserServiceWithClient(deps.Redis)
+	}
+	return NewUserAPIWithServices(
+		authsvc.NewUserServiceWithDB(deps.DB),
+		authsvc.NewConsoleRouteServiceWithDB(deps.DB),
+		authsvc.NewConsoleSessionServiceWithDB(deps.DB),
+		onlineUserService,
+		systemsvc.NewAuditLogServiceWithDB(deps.DB),
+	)
+}
+
+func newOAuthAPIFromDeps(deps sharedapi.Dependencies) *OAuthAPI {
+	if deps.DB == nil {
+		return NewOAuthAPI()
+	}
+	return NewOAuthAPIWithService(authsvc.NewOAuthServiceWithDB(deps.DB))
+}
+
+func newMenuAPIFromDeps(deps sharedapi.Dependencies) *MenuAPI {
+	if deps.DB == nil {
+		return NewMenuAPI()
+	}
+	return NewMenuAPIWithService(systemsvc.NewMenuUserServiceWithDB(deps.DB))
+}
 
 // RegisterPublicRoutes mounts unauthenticated authentication routes using
 // legacy global fallbacks.
@@ -15,7 +50,7 @@ func RegisterPublicRoutes(r gin.IRoutes) {
 // RegisterPublicRoutesWithDeps mounts unauthenticated authentication routes
 // with injected infrastructure handles.
 func RegisterPublicRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies) {
-	userAPI := NewUserAPI()
+	userAPI := newUserAPIFromDeps(deps)
 	r.POST("/login", userAPI.Login)
 	r.POST("/login/2fa/verify", userAPI.VerifyTOTPLogin)
 	r.POST("/auth/login", userAPI.LoginConsole)
@@ -27,7 +62,7 @@ func RegisterPublicRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies) {
 	r.GET("/captcha", captchaAPI.GetCaptcha)
 	r.POST("/captcha/verify", captchaAPI.VerifyCaptcha)
 
-	oauthAPI := NewOAuthAPI()
+	oauthAPI := newOAuthAPIFromDeps(deps)
 	r.GET("/oauth/github/login", oauthAPI.GithubLogin)
 	r.GET("/oauth/github/callback", oauthAPI.GithubCallback)
 	r.GET("/oauth/wechat/login", oauthAPI.WechatLogin)
@@ -43,7 +78,7 @@ func RegisterProtectedRoutes(r gin.IRoutes) {
 // RegisterProtectedRoutesWithDeps mounts authenticated console/user
 // authentication routes with injected infrastructure handles.
 func RegisterProtectedRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies) {
-	userAPI := NewUserAPI()
+	userAPI := newUserAPIFromDeps(deps)
 	r.GET("/auth/me", userAPI.GetConsoleSession)
 	r.GET("/auth/routes", userAPI.GetConsoleRoutes)
 	r.POST("/auth/logout", userAPI.LogoutConsole)
@@ -61,10 +96,10 @@ func RegisterProtectedRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies)
 	r.POST("/user/2fa/recovery-codes", userAPI.RegenerateTOTPRecoveryCodes)
 	r.POST("/logout", userAPI.Logout)
 
-	menuAPI := NewMenuAPI()
+	menuAPI := newMenuAPIFromDeps(deps)
 	r.GET("/user/menus", menuAPI.GetUserMenus)
 
-	oauthAPI := NewOAuthAPI()
+	oauthAPI := newOAuthAPIFromDeps(deps)
 	r.POST("/oauth/bind", oauthAPI.BindOAuth)
 	r.POST("/oauth/unbind", oauthAPI.UnbindOAuth)
 }

--- a/server/internal/api/auth/user.go
+++ b/server/internal/api/auth/user.go
@@ -50,6 +50,23 @@ func NewUserAPI() *UserAPI {
 	}
 }
 
+// NewUserAPIWithServices creates a UserAPI instance from injected services.
+func NewUserAPIWithServices(
+	userService auth.UserService,
+	consoleRouteService auth.ConsoleRouteService,
+	consoleSessionService auth.ConsoleSessionService,
+	onlineUserService onlineUserRecorder,
+	auditService system.AuditLogService,
+) *UserAPI {
+	return &UserAPI{
+		userService:           userService,
+		consoleRouteService:   consoleRouteService,
+		consoleSessionService: consoleSessionService,
+		onlineUserService:     onlineUserService,
+		auditService:          auditService,
+	}
+}
+
 // Login authenticates a user.
 func (a *UserAPI) Login(c *gin.Context) {
 	var req auth.LoginRequest

--- a/server/internal/api/common/health.go
+++ b/server/internal/api/common/health.go
@@ -49,6 +49,12 @@ func NewHealthAPIWithDatabaseClient(client DatabaseClient) *HealthAPI {
 	return &HealthAPI{databaseClient: client}
 }
 
+// NewHealthAPIWithClients creates a HealthAPI with injected database and
+// Redis clients. Nil clients keep the legacy global fallbacks active.
+func NewHealthAPIWithClients(databaseClient DatabaseClient, redisClient RedisPingClient) *HealthAPI {
+	return &HealthAPI{databaseClient: databaseClient, redisClient: redisClient}
+}
+
 // Health returns a lightweight health snapshot.
 func (a *HealthAPI) Health(c *gin.Context) {
 	response.Success(c, gin.H{

--- a/server/internal/api/common/routes.go
+++ b/server/internal/api/common/routes.go
@@ -1,10 +1,20 @@
 package common
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
+)
 
-// RegisterPublicRoutes mounts unauthenticated health, metrics, and IP lookup routes.
+// RegisterPublicRoutes mounts unauthenticated health, metrics, and IP lookup
+// routes using legacy global fallbacks.
 func RegisterPublicRoutes(r gin.IRoutes) {
-	healthAPI := NewHealthAPI()
+	RegisterPublicRoutesWithDeps(r, sharedapi.Dependencies{})
+}
+
+// RegisterPublicRoutesWithDeps mounts unauthenticated health, metrics, and IP
+// lookup routes with injected infrastructure handles.
+func RegisterPublicRoutesWithDeps(r gin.IRoutes, deps sharedapi.Dependencies) {
+	healthAPI := newHealthAPIFromDeps(deps)
 	r.GET("/health", healthAPI.Health)
 	r.GET("/health/check", healthAPI.HealthCheck)
 	r.GET("/health/live", healthAPI.Liveness)
@@ -16,4 +26,22 @@ func RegisterPublicRoutes(r gin.IRoutes) {
 	r.GET("/ip/info", ipInfoAPI.GetIPInfo)
 	r.GET("/ip/location", ipInfoAPI.GetIPLocation)
 	r.GET("/ip/me", ipInfoAPI.GetMyIPInfo)
+}
+
+// newHealthAPIFromDeps assembles a HealthAPI from injected handles, falling
+// back to the legacy zero-value wiring when no handles are provided. The nil
+// guards keep typed-nil pointers out of the client interfaces.
+func newHealthAPIFromDeps(deps sharedapi.Dependencies) *HealthAPI {
+	var databaseClient DatabaseClient
+	if deps.DB != nil {
+		databaseClient = deps.DB
+	}
+	var redisClient RedisPingClient
+	if deps.Redis != nil {
+		redisClient = deps.Redis
+	}
+	if databaseClient == nil && redisClient == nil {
+		return NewHealthAPI()
+	}
+	return NewHealthAPIWithClients(databaseClient, redisClient)
 }

--- a/server/internal/api/monitor/mysql.go
+++ b/server/internal/api/monitor/mysql.go
@@ -16,6 +16,11 @@ func NewMySQLAPI() *MySQLAPI {
 	}
 }
 
+// NewMySQLAPIWithService creates a MySQLAPI instance from an injected service.
+func NewMySQLAPIWithService(service *monitor.MySQLService) *MySQLAPI {
+	return &MySQLAPI{service: service}
+}
+
 // GetMySQLInfo returns MySQL information.
 func (a *MySQLAPI) GetMySQLInfo(c *gin.Context) {
 	data, err := a.service.GetMySQLInfoContext(c.Request.Context())

--- a/server/internal/api/monitor/redis.go
+++ b/server/internal/api/monitor/redis.go
@@ -16,6 +16,11 @@ func NewRedisAPI() *RedisAPI {
 	}
 }
 
+// NewRedisAPIWithService creates a RedisAPI instance from an injected service.
+func NewRedisAPIWithService(service *monitor.RedisService) *RedisAPI {
+	return &RedisAPI{service: service}
+}
+
 // GetRedisInfo returns Redis information.
 func (a *RedisAPI) GetRedisInfo(c *gin.Context) {
 	data, err := a.service.GetRedisInfoContext(c.Request.Context())

--- a/server/internal/api/monitor/routes.go
+++ b/server/internal/api/monitor/routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	"github.com/go-admin-kit/server/internal/middleware"
+	monitorsvc "github.com/go-admin-kit/server/internal/service/monitor"
 )
 
 // RegisterProtectedRoutes mounts authenticated system monitoring routes using
@@ -17,7 +18,13 @@ func RegisterProtectedRoutes(r *gin.RouterGroup) {
 func RegisterProtectedRoutesWithDeps(r *gin.RouterGroup, deps sharedapi.Dependencies) {
 	serverAPI := NewServerAPI()
 	mysqlAPI := NewMySQLAPI()
+	if deps.DB != nil {
+		mysqlAPI = NewMySQLAPIWithService(monitorsvc.NewMySQLServiceWithDB(deps.DB))
+	}
 	redisAPI := NewRedisAPI()
+	if deps.Redis != nil {
+		redisAPI = NewRedisAPIWithService(monitorsvc.NewRedisServiceWithClient(deps.Redis))
+	}
 	jobAPI := NewJobAPI()
 
 	monitorGroup := r.Group("/monitor")

--- a/server/internal/api/monitor/routes.go
+++ b/server/internal/api/monitor/routes.go
@@ -2,11 +2,19 @@ package monitor
 
 import (
 	"github.com/gin-gonic/gin"
+	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	"github.com/go-admin-kit/server/internal/middleware"
 )
 
-// RegisterProtectedRoutes mounts authenticated system monitoring routes.
+// RegisterProtectedRoutes mounts authenticated system monitoring routes using
+// legacy global fallbacks.
 func RegisterProtectedRoutes(r *gin.RouterGroup) {
+	RegisterProtectedRoutesWithDeps(r, sharedapi.Dependencies{})
+}
+
+// RegisterProtectedRoutesWithDeps mounts authenticated system monitoring
+// routes with injected infrastructure handles.
+func RegisterProtectedRoutesWithDeps(r *gin.RouterGroup, deps sharedapi.Dependencies) {
 	serverAPI := NewServerAPI()
 	mysqlAPI := NewMySQLAPI()
 	redisAPI := NewRedisAPI()

--- a/server/internal/api/monitor/routes_test.go
+++ b/server/internal/api/monitor/routes_test.go
@@ -5,13 +5,16 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
-	"github.com/go-admin-kit/server/internal/pkg/database"
+	monitorsvc "github.com/go-admin-kit/server/internal/service/monitor"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestRegisterProtectedRoutes(t *testing.T) {
-	setupMonitorRouteSQLMock(t)
+	db := setupMonitorRouteSQLMock(t)
+	// Initialize the job service singleton with the injected database so route
+	// registration does not consult the global handle.
+	monitorsvc.InitJobService(db)
 	routes := registeredMonitorRoutes(func(r *gin.RouterGroup) {
 		RegisterProtectedRoutes(r)
 	})
@@ -36,10 +39,9 @@ func TestRegisterProtectedRoutes(t *testing.T) {
 	}
 }
 
-func setupMonitorRouteSQLMock(t *testing.T) {
+func setupMonitorRouteSQLMock(t *testing.T) *gorm.DB {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -56,14 +58,13 @@ func setupMonitorRouteSQLMock(t *testing.T) {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
 
-	database.DB = db
 	t.Cleanup(func() {
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
+	return db
 }
 
 func registeredMonitorRoutes(register func(*gin.RouterGroup)) map[string]struct{} {

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -84,7 +84,7 @@ func SetupRoutes(router *gin.Engine) {
 func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 	api := router.Group("/api/v1")
 
-	common.RegisterPublicRoutes(api)
+	common.RegisterPublicRoutesWithDeps(api, deps)
 
 	apis := newSystemAPIs(deps)
 	notificationAPI := apis.notification

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -8,7 +8,72 @@ import (
 	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	"github.com/go-admin-kit/server/internal/api/system"
 	"github.com/go-admin-kit/server/internal/middleware"
+	authsvc "github.com/go-admin-kit/server/internal/service/auth"
+	systemsvc "github.com/go-admin-kit/server/internal/service/system"
 )
+
+// systemAPIs bundles the system-domain API handlers mounted by SetupRoutes.
+type systemAPIs struct {
+	notification   *system.NotificationAPI
+	userMgmt       *system.UserManagementAPI
+	roleMgmt       *system.RoleManagementAPI
+	permissionMgmt *system.PermissionManagementAPI
+	menuMgmt       *system.MenuManagementAPI
+	department     *system.DepartmentAPI
+	operationLog   *system.OperationLogAPI
+	auditLog       *system.AuditLogAPI
+	onlineUser     *system.OnlineUserAPI
+	notice         *system.NoticeAPI
+	file           *system.FileAPI
+	loginLog       *system.LoginLogAPI
+	dict           *system.DictAPI
+	setting        *system.SettingAPI
+}
+
+// newSystemAPIs assembles system-domain APIs from injected handles, falling
+// back to the legacy zero-value wiring when no database handle is provided.
+func newSystemAPIs(deps sharedapi.Dependencies) systemAPIs {
+	if deps.DB == nil {
+		return systemAPIs{
+			notification:   system.NewNotificationAPI(),
+			userMgmt:       system.NewUserManagementAPI(),
+			roleMgmt:       system.NewRoleManagementAPI(),
+			permissionMgmt: system.NewPermissionManagementAPI(),
+			menuMgmt:       system.NewMenuManagementAPI(),
+			department:     system.NewDepartmentAPI(),
+			operationLog:   system.NewOperationLogAPI(),
+			auditLog:       system.NewAuditLogAPI(),
+			onlineUser:     system.NewOnlineUserAPI(),
+			notice:         system.NewNoticeAPI(),
+			file:           system.NewFileAPI(),
+			loginLog:       system.NewLoginLogAPI(),
+			dict:           system.NewDictAPI(),
+			setting:        system.NewSettingAPI(),
+		}
+	}
+
+	db := deps.DB
+	onlineUserService := &systemsvc.OnlineUserService{}
+	if deps.Redis != nil {
+		onlineUserService = systemsvc.NewOnlineUserServiceWithClient(deps.Redis)
+	}
+	return systemAPIs{
+		notification:   system.NewNotificationAPIWithService(systemsvc.NewNoticeServiceWithDB(db)),
+		userMgmt:       system.NewUserManagementAPIWithService(systemsvc.NewUserServiceWithDB(db)),
+		roleMgmt:       system.NewRoleManagementAPIWithService(systemsvc.NewRoleServiceWithDB(db)),
+		permissionMgmt: system.NewPermissionManagementAPIWithService(systemsvc.NewPermissionServiceWithDB(db)),
+		menuMgmt:       system.NewMenuManagementAPIWithService(systemsvc.NewMenuServiceWithDB(db)),
+		department:     system.NewDepartmentAPIWithService(systemsvc.NewDepartmentServiceWithDB(db)),
+		operationLog:   system.NewOperationLogAPIWithService(systemsvc.NewOperationLogServiceWithDB(db)),
+		auditLog:       system.NewAuditLogAPIWithService(systemsvc.NewAuditLogServiceWithDB(db)),
+		onlineUser:     system.NewOnlineUserAPIWithServices(onlineUserService, authsvc.NewUserServiceWithDB(db)),
+		notice:         system.NewNoticeAPIWithService(systemsvc.NewNoticeServiceWithDB(db)),
+		file:           system.NewFileAPIWithService(systemsvc.NewFileServiceWithDB(db)),
+		loginLog:       system.NewLoginLogAPIWithService(systemsvc.NewLoginLogServiceWithDB(db)),
+		dict:           system.NewDictAPIWithService(systemsvc.NewDictServiceWithDB(db)),
+		setting:        system.NewSettingAPIWithService(systemsvc.NewSettingServiceWithDB(db)),
+	}
+}
 
 // SetupRoutes mounts the clean Go Admin Kit API using legacy global fallbacks.
 func SetupRoutes(router *gin.Engine) {
@@ -21,7 +86,8 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 
 	common.RegisterPublicRoutes(api)
 
-	notificationAPI := system.NewNotificationAPI()
+	apis := newSystemAPIs(deps)
+	notificationAPI := apis.notification
 	public := api.Group("/")
 	{
 		auth.RegisterPublicRoutesWithDeps(public, deps)
@@ -34,7 +100,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		auth.RegisterProtectedRoutesWithDeps(protected, deps)
 		protected.POST("/ws/notifications/ticket", notificationAPI.CreateTicket)
 
-		userMgmtAPI := system.NewUserManagementAPI()
+		userMgmtAPI := apis.userMgmt
 		protected.GET("/users", middleware.PermissionMiddleware("system:user:list"), userMgmtAPI.GetUserList)
 		protected.POST("/users", middleware.PermissionMiddleware("system:user:create"), userMgmtAPI.CreateUser)
 		protected.GET("/users/:id", middleware.PermissionMiddleware("system:user:detail"), userMgmtAPI.GetUser)
@@ -43,7 +109,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.PUT("/users/:id/status", middleware.PermissionMiddleware("system:user:update"), userMgmtAPI.UpdateUserStatus)
 		protected.POST("/users/:id/roles", middleware.PermissionMiddleware("system:user:update"), userMgmtAPI.AssignRoles)
 
-		roleMgmtAPI := system.NewRoleManagementAPI()
+		roleMgmtAPI := apis.roleMgmt
 		protected.GET("/roles", middleware.PermissionMiddleware("system:role:list"), roleMgmtAPI.GetRoleList)
 		protected.GET("/roles/all", middleware.PermissionMiddleware("system:role:list"), roleMgmtAPI.GetAllRoles)
 		protected.GET("/roles/:id", middleware.PermissionMiddleware("system:role:list"), roleMgmtAPI.GetRole)
@@ -52,7 +118,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.DELETE("/roles/:id", middleware.PermissionMiddleware("system:role:delete"), roleMgmtAPI.DeleteRole)
 		protected.POST("/roles/:id/permissions", middleware.PermissionMiddleware("system:role:update"), roleMgmtAPI.AssignPermissions)
 
-		permissionMgmtAPI := system.NewPermissionManagementAPI()
+		permissionMgmtAPI := apis.permissionMgmt
 		protected.GET("/permissions", middleware.PermissionMiddleware("system:permission:list"), permissionMgmtAPI.GetPermissionList)
 		protected.GET("/permissions/tree", middleware.PermissionMiddleware("system:permission:list"), permissionMgmtAPI.GetPermissionTree)
 		protected.GET("/permissions/:id", middleware.PermissionMiddleware("system:permission:list"), permissionMgmtAPI.GetPermission)
@@ -60,7 +126,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.PUT("/permissions/:id", middleware.PermissionMiddleware("system:permission:update"), permissionMgmtAPI.UpdatePermission)
 		protected.DELETE("/permissions/:id", middleware.PermissionMiddleware("system:permission:delete"), permissionMgmtAPI.DeletePermission)
 
-		menuMgmtAPI := system.NewMenuManagementAPI()
+		menuMgmtAPI := apis.menuMgmt
 		protected.GET("/menus", middleware.PermissionMiddleware("system:menu:list"), menuMgmtAPI.GetMenuList)
 		protected.GET("/menus/tree", middleware.PermissionMiddleware("system:menu:list"), menuMgmtAPI.GetMenuTree)
 		protected.GET("/menus/:id", middleware.PermissionMiddleware("system:menu:list"), menuMgmtAPI.GetMenu)
@@ -68,7 +134,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.PUT("/menus/:id", middleware.PermissionMiddleware("system:menu:update"), menuMgmtAPI.UpdateMenu)
 		protected.DELETE("/menus/:id", middleware.PermissionMiddleware("system:menu:delete"), menuMgmtAPI.DeleteMenu)
 
-		deptAPI := system.NewDepartmentAPI()
+		deptAPI := apis.department
 		protected.GET("/departments", middleware.PermissionMiddleware("system:department:list"), deptAPI.GetDepartmentList)
 		protected.GET("/departments/tree", middleware.PermissionMiddleware("system:department:list"), deptAPI.GetDepartmentTree)
 		protected.GET("/departments/all", middleware.PermissionMiddleware("system:department:list"), deptAPI.GetAllDepartments)
@@ -77,8 +143,8 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.PUT("/departments/:id", middleware.PermissionMiddleware("system:department:update"), deptAPI.UpdateDepartment)
 		protected.DELETE("/departments/:id", middleware.PermissionMiddleware("system:department:delete"), deptAPI.DeleteDepartment)
 
-		opLogAPI := system.NewOperationLogAPI()
-		auditLogAPI := system.NewAuditLogAPI()
+		opLogAPI := apis.operationLog
+		auditLogAPI := apis.auditLog
 		protected.GET("/operation-logs", middleware.PermissionMiddleware("system:log:operation"), opLogAPI.GetOperationLogs)
 		protected.GET("/operation-logs/stats", middleware.PermissionMiddleware("system:log:operation"), opLogAPI.GetOperationLogStats)
 		protected.GET("/operation-logs/export", middleware.PermissionMiddleware("system:log:operation"), opLogAPI.ExportOperationLogs)
@@ -86,12 +152,12 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.DELETE("/operation-logs/clear", middleware.PermissionMiddleware("system:log:operation:clear"), opLogAPI.ClearOperationLogs)
 		protected.GET("/logs/audit", middleware.PermissionMiddleware("system:log:audit"), auditLogAPI.GetAuditLogs)
 
-		onlineUserAPI := system.NewOnlineUserAPI()
+		onlineUserAPI := apis.onlineUser
 		protected.GET("/online-users", middleware.PermissionMiddleware("system:online-user:list"), onlineUserAPI.GetOnlineUsers)
 		protected.GET("/online-users/count", middleware.PermissionMiddleware("system:online-user:list"), onlineUserAPI.GetOnlineUserCount)
 		protected.DELETE("/online-users/:token_id", middleware.PermissionMiddleware("system:online-user:kick"), onlineUserAPI.ForceLogout)
 
-		noticeAPI := system.NewNoticeAPI()
+		noticeAPI := apis.notice
 		protected.GET("/notices", middleware.PermissionMiddleware("system:notice:list"), noticeAPI.GetNoticeList)
 		protected.GET("/notices/active", noticeAPI.GetActiveNotices)
 		protected.GET("/notices/:id", middleware.PermissionMiddleware("system:notice:list"), noticeAPI.GetNotice)
@@ -100,7 +166,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.DELETE("/notices/:id", middleware.PermissionMiddleware("system:notice:delete"), noticeAPI.DeleteNotice)
 		protected.PUT("/notices/:id/status", middleware.PermissionMiddleware("system:notice:update"), noticeAPI.UpdateNoticeStatus)
 
-		fileAPI := system.NewFileAPI()
+		fileAPI := apis.file
 		protected.POST("/files/upload", middleware.PermissionMiddleware("system:file:upload"), fileAPI.Upload)
 		protected.POST("/files/upload/multiple", middleware.PermissionMiddleware("system:file:upload"), fileAPI.UploadMultiple)
 		protected.GET("/files", middleware.PermissionMiddleware("system:file:list"), fileAPI.GetFileList)
@@ -113,7 +179,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.DELETE("/files/:id", middleware.PermissionMiddleware("system:file:delete"), fileAPI.DeleteFile)
 		protected.DELETE("/files/batch", middleware.PermissionMiddleware("system:file:delete"), fileAPI.DeleteFiles)
 
-		loginLogAPI := system.NewLoginLogAPI()
+		loginLogAPI := apis.loginLog
 		protected.GET("/login-logs", middleware.PermissionMiddleware("system:log:login"), loginLogAPI.GetLoginLogs)
 		protected.GET("/login-logs/my", loginLogAPI.GetMyLoginLogs)
 		protected.GET("/login-logs/stats", middleware.PermissionMiddleware("system:log:login"), loginLogAPI.GetLoginStats)
@@ -122,7 +188,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.GET("/login-logs/user/:user_id", middleware.PermissionMiddleware("system:log:login"), loginLogAPI.GetUserLoginHistory)
 		protected.DELETE("/login-logs/clear", middleware.PermissionMiddleware("system:log:login"), loginLogAPI.ClearLoginLogs)
 
-		dictAPI := system.NewDictAPI()
+		dictAPI := apis.dict
 		protected.GET("/dict-types", middleware.PermissionMiddleware("system:dict:list"), dictAPI.GetTypeList)
 		protected.GET("/dict-types/all", middleware.PermissionMiddleware("system:dict:list"), dictAPI.GetAllTypes)
 		protected.GET("/dict-types/:id", middleware.PermissionMiddleware("system:dict:list"), dictAPI.GetType)
@@ -141,7 +207,7 @@ func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 		protected.GET("/dicts", dictAPI.GetMultipleDictData)
 		protected.GET("/dicts/all", dictAPI.GetAllDictData)
 
-		settingAPI := system.NewSettingAPI()
+		settingAPI := apis.setting
 		protected.GET("/system-settings", middleware.PermissionMiddleware("system:setting:list"), settingAPI.GetSettings)
 		protected.POST("/system-settings/batch", middleware.PermissionMiddleware("system:setting:update"), settingAPI.BatchUpsertSettings)
 		protected.GET("/system-settings/:key", middleware.PermissionMiddleware("system:setting:list"), settingAPI.GetSetting)

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -5,12 +5,18 @@ import (
 	"github.com/go-admin-kit/server/internal/api/auth"
 	"github.com/go-admin-kit/server/internal/api/common"
 	"github.com/go-admin-kit/server/internal/api/monitor"
+	sharedapi "github.com/go-admin-kit/server/internal/api/shared"
 	"github.com/go-admin-kit/server/internal/api/system"
 	"github.com/go-admin-kit/server/internal/middleware"
 )
 
-// SetupRoutes mounts the clean Go Admin Kit API.
+// SetupRoutes mounts the clean Go Admin Kit API using legacy global fallbacks.
 func SetupRoutes(router *gin.Engine) {
+	SetupRoutesWithDeps(router, sharedapi.Dependencies{})
+}
+
+// SetupRoutesWithDeps mounts the API with injected infrastructure handles.
+func SetupRoutesWithDeps(router *gin.Engine, deps sharedapi.Dependencies) {
 	api := router.Group("/api/v1")
 
 	common.RegisterPublicRoutes(api)
@@ -18,14 +24,14 @@ func SetupRoutes(router *gin.Engine) {
 	notificationAPI := system.NewNotificationAPI()
 	public := api.Group("/")
 	{
-		auth.RegisterPublicRoutes(public)
+		auth.RegisterPublicRoutesWithDeps(public, deps)
 		public.GET("/ws/notifications", notificationAPI.Connect)
 	}
 
 	protected := api.Group("/")
 	protected.Use(middleware.AuthMiddleware(), middleware.OperationLogger())
 	{
-		auth.RegisterProtectedRoutes(protected)
+		auth.RegisterProtectedRoutesWithDeps(protected, deps)
 		protected.POST("/ws/notifications/ticket", notificationAPI.CreateTicket)
 
 		userMgmtAPI := system.NewUserManagementAPI()
@@ -142,7 +148,7 @@ func SetupRoutes(router *gin.Engine) {
 		protected.PUT("/system-settings/:key", middleware.PermissionMiddleware("system:setting:update"), settingAPI.UpsertSetting)
 		protected.DELETE("/system-settings/:key", middleware.PermissionMiddleware("system:setting:delete"), settingAPI.DeleteSetting)
 
-		monitor.RegisterProtectedRoutes(protected)
+		monitor.RegisterProtectedRoutesWithDeps(protected, deps)
 	}
 
 	system.ServeStaticFiles(router)

--- a/server/internal/api/shared/dependencies.go
+++ b/server/internal/api/shared/dependencies.go
@@ -1,0 +1,13 @@
+package shared
+
+import (
+	goredis "github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
+)
+
+// Dependencies carries the runtime infrastructure handles injected at the
+// route composition root. Zero value keeps legacy global fallbacks active.
+type Dependencies struct {
+	DB    *gorm.DB
+	Redis *goredis.Client
+}

--- a/server/internal/api/system/audit_log.go
+++ b/server/internal/api/system/audit_log.go
@@ -17,6 +17,11 @@ func NewAuditLogAPI() *AuditLogAPI {
 	}
 }
 
+// NewAuditLogAPIWithService creates an AuditLogAPI instance from an injected service.
+func NewAuditLogAPIWithService(logService service.AuditLogService) *AuditLogAPI {
+	return &AuditLogAPI{logService: logService}
+}
+
 func (a *AuditLogAPI) GetAuditLogs(c *gin.Context) {
 	var req service.AuditLogListRequest
 	if err := c.ShouldBindQuery(&req); err != nil {

--- a/server/internal/api/system/department.go
+++ b/server/internal/api/system/department.go
@@ -20,6 +20,11 @@ func NewDepartmentAPI() *DepartmentAPI {
 	}
 }
 
+// NewDepartmentAPIWithService creates a DepartmentAPI instance from an injected service.
+func NewDepartmentAPIWithService(deptService system.DepartmentService) *DepartmentAPI {
+	return &DepartmentAPI{deptService: deptService}
+}
+
 // GetDepartmentList returns paginated departments.
 func (a *DepartmentAPI) GetDepartmentList(c *gin.Context) {
 	var req system.DepartmentListRequest

--- a/server/internal/api/system/dict.go
+++ b/server/internal/api/system/dict.go
@@ -21,6 +21,11 @@ func NewDictAPI() *DictAPI {
 	}
 }
 
+// NewDictAPIWithService creates a DictAPI instance from an injected service.
+func NewDictAPIWithService(dictService system.DictService) *DictAPI {
+	return &DictAPI{dictService: dictService}
+}
+
 // ========== Dict types ==========
 
 // GetTypeList returns paginated dictionary types.

--- a/server/internal/api/system/file.go
+++ b/server/internal/api/system/file.go
@@ -28,6 +28,11 @@ func NewFileAPI() *FileAPI {
 	}
 }
 
+// NewFileAPIWithService creates a FileAPI instance from an injected service.
+func NewFileAPIWithService(fileService *system.FileService) *FileAPI {
+	return &FileAPI{fileService: fileService}
+}
+
 // Upload uploads a single file.
 func (a *FileAPI) Upload(c *gin.Context) {
 	file, err := c.FormFile("file")

--- a/server/internal/api/system/login_log.go
+++ b/server/internal/api/system/login_log.go
@@ -24,6 +24,11 @@ func NewLoginLogAPI() *LoginLogAPI {
 	}
 }
 
+// NewLoginLogAPIWithService creates a LoginLogAPI instance from an injected service.
+func NewLoginLogAPIWithService(logService system.LoginLogService) *LoginLogAPI {
+	return &LoginLogAPI{logService: logService}
+}
+
 // GetLoginLogs returns paginated login logs.
 func (a *LoginLogAPI) GetLoginLogs(c *gin.Context) {
 	var req system.LoginLogListRequest

--- a/server/internal/api/system/menu.go
+++ b/server/internal/api/system/menu.go
@@ -20,6 +20,11 @@ func NewMenuManagementAPI() *MenuManagementAPI {
 	}
 }
 
+// NewMenuManagementAPIWithService creates a MenuManagementAPI instance from an injected service.
+func NewMenuManagementAPIWithService(menuService system.MenuService) *MenuManagementAPI {
+	return &MenuManagementAPI{menuService: menuService}
+}
+
 // GetMenuList returns paginated menus.
 func (a *MenuManagementAPI) GetMenuList(c *gin.Context) {
 	var req system.MenuListRequest

--- a/server/internal/api/system/notice.go
+++ b/server/internal/api/system/notice.go
@@ -34,6 +34,16 @@ func NewNoticeAPI() *NoticeAPI {
 	}
 }
 
+// NewNoticeAPIWithService creates a NoticeAPI instance from an injected
+// service. Broadcaster and email notifier keep their default implementations.
+func NewNoticeAPIWithService(noticeService system.NoticeService) *NoticeAPI {
+	return &NoticeAPI{
+		noticeService: noticeService,
+		broadcaster:   system.DefaultNotificationBroadcaster(),
+		emailNotifier: system.DefaultNoticeEmailNotifier(),
+	}
+}
+
 // GetNoticeList returns paginated notices.
 func (a *NoticeAPI) GetNoticeList(c *gin.Context) {
 	var req system.NoticeListRequest

--- a/server/internal/api/system/notice_test.go
+++ b/server/internal/api/system/notice_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/go-admin-kit/server/internal/model"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	systemsvc "github.com/go-admin-kit/server/internal/service/system"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -63,7 +62,7 @@ func TestNoticeAPIMessagesUseEnglish(t *testing.T) {
 
 func TestCreateNoticeEmailFailureDoesNotFailRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	mock := setupNoticeAPITestDB(t)
+	db, mock := setupNoticeAPITestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO `notices`").
 		WillReturnResult(sqlmock.NewResult(42, 1))
@@ -81,7 +80,7 @@ func TestCreateNoticeEmailFailureDoesNotFailRequest(t *testing.T) {
 
 	emailNotifier := &failingNoticeEmailNotifier{err: errors.New("smtp unavailable")}
 	api := &NoticeAPI{
-		noticeService: systemsvc.NoticeService{},
+		noticeService: systemsvc.NewNoticeServiceWithDB(db),
 		emailNotifier: emailNotifier,
 	}
 
@@ -95,7 +94,7 @@ func TestCreateNoticeEmailFailureDoesNotFailRequest(t *testing.T) {
 
 func TestUpdateNoticeStatusEmailFailureDoesNotFailRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	mock := setupNoticeAPITestDB(t)
+	db, mock := setupNoticeAPITestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE `notices` SET `status`=").
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -113,7 +112,7 @@ func TestUpdateNoticeStatusEmailFailureDoesNotFailRequest(t *testing.T) {
 
 	emailNotifier := &failingNoticeEmailNotifier{err: errors.New("smtp unavailable")}
 	api := &NoticeAPI{
-		noticeService: systemsvc.NoticeService{},
+		noticeService: systemsvc.NewNoticeServiceWithDB(db),
 		broadcaster:   systemsvc.NewNotificationBroadcaster(),
 		emailNotifier: emailNotifier,
 	}
@@ -128,7 +127,7 @@ func TestUpdateNoticeStatusEmailFailureDoesNotFailRequest(t *testing.T) {
 
 func TestUpdateNoticeSendsEmailWhenNoticeBecomesEnabled(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	mock := setupNoticeAPITestDB(t)
+	db, mock := setupNoticeAPITestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `notices` WHERE `notices`.`id` = ? ORDER BY `notices`.`id` LIMIT ?")).
 		WithArgs(7, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "title", "content", "type", "status"}).
@@ -151,7 +150,7 @@ func TestUpdateNoticeSendsEmailWhenNoticeBecomesEnabled(t *testing.T) {
 
 	emailNotifier := &failingNoticeEmailNotifier{err: errors.New("smtp unavailable")}
 	api := &NoticeAPI{
-		noticeService: systemsvc.NoticeService{},
+		noticeService: systemsvc.NewNoticeServiceWithDB(db),
 		broadcaster:   systemsvc.NewNotificationBroadcaster(),
 		emailNotifier: emailNotifier,
 	}
@@ -166,7 +165,7 @@ func TestUpdateNoticeSendsEmailWhenNoticeBecomesEnabled(t *testing.T) {
 
 func TestCreateNoticeReturnsBeforeBlockedEmailNotifier(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	mock := setupNoticeAPITestDB(t)
+	db, mock := setupNoticeAPITestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO `notices`").
 		WillReturnResult(sqlmock.NewResult(42, 1))
@@ -187,7 +186,7 @@ func TestCreateNoticeReturnsBeforeBlockedEmailNotifier(t *testing.T) {
 		started: make(chan struct{}),
 	}
 	api := &NoticeAPI{
-		noticeService: systemsvc.NoticeService{},
+		noticeService: systemsvc.NewNoticeServiceWithDB(db),
 		broadcaster:   systemsvc.NewNotificationBroadcaster(),
 		emailNotifier: emailNotifier,
 	}
@@ -251,10 +250,9 @@ func waitForNoticeEmailCalls(t *testing.T, notifier *failingNoticeEmailNotifier,
 	t.Fatalf("email notifier calls = %d, want %d", atomic.LoadInt32(&notifier.calls), want)
 }
 
-func setupNoticeAPITestDB(t *testing.T) sqlmock.Sqlmock {
+func setupNoticeAPITestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -267,14 +265,12 @@ func setupNoticeAPITestDB(t *testing.T) sqlmock.Sqlmock {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
 
-	database.DB = db
 	t.Cleanup(func() {
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
 
-	return mock
+	return db, mock
 }

--- a/server/internal/api/system/notification_ws.go
+++ b/server/internal/api/system/notification_ws.go
@@ -46,6 +46,15 @@ func NewNotificationAPI() *NotificationAPI {
 	}
 }
 
+// NewNotificationAPIWithService creates a NotificationAPI instance from an
+// injected notice service. The broadcaster keeps its default implementation.
+func NewNotificationAPIWithService(noticeService systemsvc.NoticeService) *NotificationAPI {
+	return &NotificationAPI{
+		noticeService: noticeService,
+		broadcaster:   systemsvc.DefaultNotificationBroadcaster(),
+	}
+}
+
 func (a *NotificationAPI) CreateTicket(c *gin.Context) {
 	userID, exists := c.Get("user_id")
 	if !exists {

--- a/server/internal/api/system/notification_ws_test.go
+++ b/server/internal/api/system/notification_ws_test.go
@@ -133,14 +133,14 @@ func TestNotificationWebSocketConsumesTicketSendsActiveNoticesAndPublishesTarget
 	})
 
 	createdAt := time.Date(2026, 5, 23, 9, 30, 0, 0, time.UTC)
-	mock := setupNoticeAPITestDB(t)
+	db, mock := setupNoticeAPITestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `notices` WHERE status = 1 AND ((start_time IS NULL OR start_time <= NOW())) AND ((end_time IS NULL OR end_time >= NOW())) ORDER BY created_at DESC")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "title", "content", "type", "status", "created_at", "updated_at"}).
 			AddRow(uint(9), "Maintenance", "Maintenance window tonight", int8(2), int8(1), createdAt, createdAt))
 
 	broadcaster := systemsvc.NewNotificationBroadcaster()
 	api := &NotificationAPI{
-		noticeService: systemsvc.NoticeService{},
+		noticeService: systemsvc.NewNoticeServiceWithDB(db),
 		broadcaster:   broadcaster,
 	}
 	router := gin.New()

--- a/server/internal/api/system/online_user.go
+++ b/server/internal/api/system/online_user.go
@@ -62,6 +62,15 @@ func NewOnlineUserAPI() *OnlineUserAPI {
 	}
 }
 
+// NewOnlineUserAPIWithServices creates an OnlineUserAPI instance from
+// injected services.
+func NewOnlineUserAPIWithServices(onlineUserService *system.OnlineUserService, roleService authsvc.UserService) *OnlineUserAPI {
+	return &OnlineUserAPI{
+		onlineUserService: onlineUserService,
+		roleLoader:        authUserRoleLoader{userService: roleService},
+	}
+}
+
 // GetOnlineUsers returns online users.
 // @Summary Get online users
 // @Tags Online User Management

--- a/server/internal/api/system/operation_log.go
+++ b/server/internal/api/system/operation_log.go
@@ -25,6 +25,11 @@ func NewOperationLogAPI() *OperationLogAPI {
 	}
 }
 
+// NewOperationLogAPIWithService creates an OperationLogAPI instance from an injected service.
+func NewOperationLogAPIWithService(logService system.OperationLogService) *OperationLogAPI {
+	return &OperationLogAPI{logService: logService}
+}
+
 // GetOperationLogs returns paginated operation logs.
 func (a *OperationLogAPI) GetOperationLogs(c *gin.Context) {
 	var req system.OperationLogListRequest

--- a/server/internal/api/system/permission.go
+++ b/server/internal/api/system/permission.go
@@ -20,6 +20,11 @@ func NewPermissionManagementAPI() *PermissionManagementAPI {
 	}
 }
 
+// NewPermissionManagementAPIWithService creates a PermissionManagementAPI instance from an injected service.
+func NewPermissionManagementAPIWithService(permissionService system.PermissionService) *PermissionManagementAPI {
+	return &PermissionManagementAPI{permissionService: permissionService}
+}
+
 // GetPermissionList returns paginated permissions.
 func (a *PermissionManagementAPI) GetPermissionList(c *gin.Context) {
 	var req system.PermissionListRequest

--- a/server/internal/api/system/role.go
+++ b/server/internal/api/system/role.go
@@ -20,6 +20,11 @@ func NewRoleManagementAPI() *RoleManagementAPI {
 	}
 }
 
+// NewRoleManagementAPIWithService creates a RoleManagementAPI instance from an injected service.
+func NewRoleManagementAPIWithService(roleService system.RoleService) *RoleManagementAPI {
+	return &RoleManagementAPI{roleService: roleService}
+}
+
 // GetRoleList returns paginated roles.
 func (a *RoleManagementAPI) GetRoleList(c *gin.Context) {
 	var req system.RoleListRequest

--- a/server/internal/api/system/setting.go
+++ b/server/internal/api/system/setting.go
@@ -16,6 +16,11 @@ func NewSettingAPI() *SettingAPI {
 	return &SettingAPI{settingService: systemsvc.SettingService{}}
 }
 
+// NewSettingAPIWithService creates a SettingAPI instance from an injected service.
+func NewSettingAPIWithService(settingService systemsvc.SettingService) *SettingAPI {
+	return &SettingAPI{settingService: settingService}
+}
+
 func (a *SettingAPI) GetSettings(c *gin.Context) {
 	settings, err := a.settingService.ListSettingsContext(c.Request.Context(), c.Query("group"))
 	if err != nil {

--- a/server/internal/api/system/user.go
+++ b/server/internal/api/system/user.go
@@ -21,6 +21,11 @@ func NewUserManagementAPI() *UserManagementAPI {
 	}
 }
 
+// NewUserManagementAPIWithService creates a UserManagementAPI instance from an injected service.
+func NewUserManagementAPIWithService(userService system.UserService) *UserManagementAPI {
+	return &UserManagementAPI{userService: userService}
+}
+
 // CreateUser creates a user.
 func (a *UserManagementAPI) CreateUser(c *gin.Context) {
 	var req system.CreateUserRequest

--- a/server/internal/architecture/composition_root_test.go
+++ b/server/internal/architecture/composition_root_test.go
@@ -56,10 +56,10 @@ var allowedBareAPIConstructorCalls = map[string]int{
 	"api/monitor/routes.go|RegisterProtectedRoutesWithDeps|NewRedisAPI":  1,
 	"api/monitor/routes.go|RegisterProtectedRoutesWithDeps|NewServerAPI": 1,
 
-	// api/common/routes.go: health/IP endpoints still assemble zero-value
-	// APIs pending dependency injection.
-	"api/common/routes.go|RegisterPublicRoutes|NewHealthAPI": 1,
-	"api/common/routes.go|RegisterPublicRoutes|NewIPInfoAPI": 1,
+	// api/common/routes.go: legacy zero-value branch for health, plus
+	// IPInfoAPI, which has no injectable infrastructure.
+	"api/common/routes.go|newHealthAPIFromDeps|NewHealthAPI":         1,
+	"api/common/routes.go|RegisterPublicRoutesWithDeps|NewIPInfoAPI": 1,
 }
 
 // TestRouteCompositionUsesInjectedAPIConstructors keeps the composition root

--- a/server/internal/architecture/composition_root_test.go
+++ b/server/internal/architecture/composition_root_test.go
@@ -1,0 +1,150 @@
+package architecture
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// bareAPIConstructorPattern matches zero-value API constructors such as
+// NewUserAPI. Injected variants (NewUserAPIWithServices) do not match because
+// they carry a suffix after "API".
+var bareAPIConstructorPattern = regexp.MustCompile(`^New\w*API$`)
+
+// allowedBareAPIConstructorCalls lists the bare (zero-value) API constructor
+// calls that route composition may still perform. Each entry is either the
+// documented legacy fallback branch taken when no dependencies are injected,
+// or an API without injectable infrastructure. New route registrations must
+// use the *WithService/*WithServices constructors fed from
+// shared.Dependencies instead of growing this list.
+var allowedBareAPIConstructorCalls = map[string]int{
+	// api/routes.go newSystemAPIs: legacy zero-value branch (deps.DB == nil).
+	"api/routes.go|newSystemAPIs|NewAuditLogAPI":             1,
+	"api/routes.go|newSystemAPIs|NewDepartmentAPI":           1,
+	"api/routes.go|newSystemAPIs|NewDictAPI":                 1,
+	"api/routes.go|newSystemAPIs|NewFileAPI":                 1,
+	"api/routes.go|newSystemAPIs|NewLoginLogAPI":             1,
+	"api/routes.go|newSystemAPIs|NewMenuManagementAPI":       1,
+	"api/routes.go|newSystemAPIs|NewNoticeAPI":               1,
+	"api/routes.go|newSystemAPIs|NewNotificationAPI":         1,
+	"api/routes.go|newSystemAPIs|NewOnlineUserAPI":           1,
+	"api/routes.go|newSystemAPIs|NewOperationLogAPI":         1,
+	"api/routes.go|newSystemAPIs|NewPermissionManagementAPI": 1,
+	"api/routes.go|newSystemAPIs|NewRoleManagementAPI":       1,
+	"api/routes.go|newSystemAPIs|NewSettingAPI":              1,
+	"api/routes.go|newSystemAPIs|NewUserManagementAPI":       1,
+
+	// api/auth/routes.go: legacy zero-value branches (deps.DB == nil) plus
+	// CaptchaAPI, which has no injectable infrastructure.
+	"api/auth/routes.go|newMenuAPIFromDeps|NewMenuAPI":              1,
+	"api/auth/routes.go|newOAuthAPIFromDeps|NewOAuthAPI":            1,
+	"api/auth/routes.go|newUserAPIFromDeps|NewUserAPI":              1,
+	"api/auth/routes.go|RegisterPublicRoutesWithDeps|NewCaptchaAPI": 1,
+
+	// api/monitor/routes.go: ServerAPI reads host metrics only; JobAPI wraps
+	// the singleton injected via InitJobService; MySQL/Redis bare calls are
+	// the legacy fallbacks replaced when deps carry the matching handle.
+	"api/monitor/routes.go|RegisterProtectedRoutesWithDeps|NewJobAPI":    1,
+	"api/monitor/routes.go|RegisterProtectedRoutesWithDeps|NewMySQLAPI":  1,
+	"api/monitor/routes.go|RegisterProtectedRoutesWithDeps|NewRedisAPI":  1,
+	"api/monitor/routes.go|RegisterProtectedRoutesWithDeps|NewServerAPI": 1,
+
+	// api/common/routes.go: health/IP endpoints still assemble zero-value
+	// APIs pending dependency injection.
+	"api/common/routes.go|RegisterPublicRoutes|NewHealthAPI": 1,
+	"api/common/routes.go|RegisterPublicRoutes|NewIPInfoAPI": 1,
+}
+
+// TestRouteCompositionUsesInjectedAPIConstructors keeps the composition root
+// honest: route registration must assemble APIs through dependency-injected
+// constructors, and every remaining bare New*API call needs an explicit
+// allowlist entry.
+func TestRouteCompositionUsesInjectedAPIConstructors(t *testing.T) {
+	apiDir := filepath.Join(internalDir, "api")
+	allowances := cloneAllowances(allowedBareAPIConstructorCalls)
+	var violations []string
+
+	err := filepath.WalkDir(apiDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Base(path) != "routes.go" {
+			return nil
+		}
+
+		fileViolations, err := bareAPIConstructorCalls(path, allowances)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, fileViolations...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan route files: %v", err)
+	}
+
+	violations = append(violations, unusedAllowances(allowances)...)
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("route composition must use dependency-injected API constructors; bare New*API calls need an explicit allowlist entry:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func bareAPIConstructorCalls(path string, allowances map[string]int) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	var violations []string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			name := calledFunctionName(call)
+			if !bareAPIConstructorPattern.MatchString(name) {
+				return true
+			}
+
+			relPath := relativeInternalPath(path)
+			allowKey := strings.Join([]string{relPath, fn.Name.Name, name}, "|")
+			if allowances[allowKey] > 0 {
+				allowances[allowKey]--
+				return true
+			}
+
+			position := fset.Position(call.Pos())
+			violations = append(violations, fmt.Sprintf("%s:%d: %s called in %s", relPath, position.Line, name, fn.Name.Name))
+			return true
+		})
+	}
+
+	return violations, nil
+}
+
+func calledFunctionName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		return fun.Sel.Name
+	default:
+		return ""
+	}
+}

--- a/server/internal/dao/auth/console_route_test.go
+++ b/server/internal/dao/auth/console_route_test.go
@@ -6,16 +6,15 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestConsoleRouteDAOListAllOrdersBySortAndKey(t *testing.T) {
-	mock := setupAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery("SELECT \\* FROM `console_routes` ORDER BY sort_order ASC,route_key ASC").
 		WillReturnRows(sqlmock.NewRows([]string{"route_key", "path", "name", "component_key"}).
 			AddRow("dashboard", "/dashboard", "Dashboard", "DashboardPage"))
 
-	routes, err := NewConsoleRouteDAO().ListAllContext(context.Background())
+	routes, err := NewConsoleRouteDAO(db).ListAllContext(context.Background())
 	if err != nil {
 		t.Fatalf("ListAllContext() error = %v", err)
 	}
@@ -25,24 +24,24 @@ func TestConsoleRouteDAOListAllOrdersBySortAndKey(t *testing.T) {
 }
 
 func TestConsoleRouteDAOListAllContextHonorsCanceledContext(t *testing.T) {
-	setupAuthDAOTestDB(t)
+	db, _ := newAuthDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := NewConsoleRouteDAO().ListAllContext(ctx)
+	_, err := NewConsoleRouteDAO(db).ListAllContext(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListAllContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestConsoleRouteDAOFindRouteKeyByPath(t *testing.T) {
-	mock := setupAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery("SELECT `route_key` FROM `console_routes` WHERE path = \\? LIMIT \\?").
 		WithArgs("/dashboard", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"route_key"}).AddRow("dashboard"))
 
-	owner, err := NewConsoleRouteDAO().FindRouteKeyByPathContext(context.Background(), "/dashboard")
+	owner, err := NewConsoleRouteDAO(db).FindRouteKeyByPathContext(context.Background(), "/dashboard")
 	if err != nil {
 		t.Fatalf("FindRouteKeyByPathContext() error = %v", err)
 	}
@@ -52,13 +51,7 @@ func TestConsoleRouteDAOFindRouteKeyByPath(t *testing.T) {
 }
 
 func TestConsoleRouteDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery("SELECT \\* FROM `console_routes` ORDER BY sort_order ASC,route_key ASC").
 		WillReturnRows(sqlmock.NewRows([]string{"route_key", "path", "name", "component_key"}).
 			AddRow("dashboard", "/dashboard", "Dashboard", "DashboardPage"))

--- a/server/internal/dao/auth/console_session_test.go
+++ b/server/internal/dao/auth/console_session_test.go
@@ -8,60 +8,10 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
-	"gorm.io/driver/mysql"
-	"gorm.io/gorm"
 )
 
 func TestConsoleSessionDAOGetBySessionIDContext(t *testing.T) {
-	mock := setupAuthDAOTestDB(t)
-	now := time.Now().UTC()
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `console_sessions` WHERE session_id = ? ORDER BY `console_sessions`.`session_id` LIMIT ?")).
-		WithArgs("session-1", 1).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "username", "issued_at", "expires_at", "created_at"}).
-			AddRow("session-1", "alice", now, now.Add(time.Hour), now))
-
-	record, err := (ConsoleSessionDAO{}).GetBySessionIDContext(context.Background(), "session-1")
-	if err != nil {
-		t.Fatalf("GetBySessionIDContext() error = %v", err)
-	}
-	if record.SessionID != "session-1" || record.Username != "alice" {
-		t.Fatalf("record = %#v, want session-1/alice", record)
-	}
-}
-
-func TestConsoleSessionDAOGetBySessionIDContextHonorsCanceledContext(t *testing.T) {
-	setupAuthDAOTestDB(t)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := (ConsoleSessionDAO{}).GetBySessionIDContext(ctx, "session-1")
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("GetBySessionIDContext() error = %v, want context.Canceled", err)
-	}
-}
-
-func TestConsoleSessionDAOReadyReflectsGlobalDatabase(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	if (ConsoleSessionDAO{}).Ready() {
-		t.Fatal("Ready() should be false when database is nil")
-	}
-}
-
-func TestConsoleSessionDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	now := time.Now().UTC()
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `console_sessions` WHERE session_id = ? ORDER BY `console_sessions`.`session_id` LIMIT ?")).
 		WithArgs("session-1", 1).
@@ -77,30 +27,39 @@ func TestConsoleSessionDAOUsesInjectedDB(t *testing.T) {
 	}
 }
 
-func setupAuthDAOTestDB(t *testing.T) sqlmock.Sqlmock {
-	t.Helper()
+func TestConsoleSessionDAOGetBySessionIDContextHonorsCanceledContext(t *testing.T) {
+	db, _ := newAuthDAOTestDB(t)
 
-	oldDB := database.DB
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("open sqlmock db: %v", err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewConsoleSessionDAO(db).GetBySessionIDContext(ctx, "session-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetBySessionIDContext() error = %v, want context.Canceled", err)
 	}
-	db, err := gorm.Open(mysql.New(mysql.Config{
-		Conn:                      sqlDB,
-		SkipInitializeWithVersion: true,
-	}), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("open gorm sqlmock db: %v", err)
+}
+
+func TestConsoleSessionDAOReadyReflectsInjectedDatabase(t *testing.T) {
+	db, _ := newAuthDAOTestDB(t)
+
+	if !NewConsoleSessionDAO(db).Ready() {
+		t.Fatal("Ready() = false, want true when a database is injected")
 	}
+}
 
-	database.DB = db
-	t.Cleanup(func() {
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet database expectations: %v", err)
-		}
-		_ = sqlDB.Close()
-		database.DB = oldDB
-	})
+func TestConsoleSessionDAOUsesInjectedDB(t *testing.T) {
+	db, mock := newAuthDAOTestDB(t)
+	now := time.Now().UTC()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `console_sessions` WHERE session_id = ? ORDER BY `console_sessions`.`session_id` LIMIT ?")).
+		WithArgs("session-1", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "username", "issued_at", "expires_at", "created_at"}).
+			AddRow("session-1", "alice", now, now.Add(time.Hour), now))
 
-	return mock
+	record, err := NewConsoleSessionDAO(db).GetBySessionIDContext(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("GetBySessionIDContext() error = %v", err)
+	}
+	if record.SessionID != "session-1" || record.Username != "alice" {
+		t.Fatalf("record = %#v, want session-1/alice", record)
+	}
 }

--- a/server/internal/dao/auth/oauth_test.go
+++ b/server/internal/dao/auth/oauth_test.go
@@ -7,17 +7,16 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestOAuthBindingDAOGetByProviderUserContext(t *testing.T) {
-	mock := setupAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `oauth_bindings` WHERE provider = ? AND provider_user_id = ? ORDER BY `oauth_bindings`.`id` LIMIT ?")).
 		WithArgs("github", "123", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "provider", "provider_user_id"}).
 			AddRow(7, 42, "github", "123"))
 
-	binding, err := (OAuthBindingDAO{}).GetByProviderUserContext(context.Background(), "github", "123")
+	binding, err := NewOAuthBindingDAO(db).GetByProviderUserContext(context.Background(), "github", "123")
 	if err != nil {
 		t.Fatalf("GetByProviderUserContext() error = %v", err)
 	}
@@ -27,25 +26,25 @@ func TestOAuthBindingDAOGetByProviderUserContext(t *testing.T) {
 }
 
 func TestOAuthBindingDAOGetByProviderUserContextHonorsCanceledContext(t *testing.T) {
-	setupAuthDAOTestDB(t)
+	db, _ := newAuthDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (OAuthBindingDAO{}).GetByProviderUserContext(ctx, "github", "123")
+	_, err := NewOAuthBindingDAO(db).GetByProviderUserContext(ctx, "github", "123")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetByProviderUserContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestOAuthBindingDAOGetByUserProviderContext(t *testing.T) {
-	mock := setupAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `oauth_bindings` WHERE user_id = ? AND provider = ? ORDER BY `oauth_bindings`.`id` LIMIT ?")).
 		WithArgs(42, "github", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "provider", "provider_user_id"}).
 			AddRow(7, 42, "github", "123"))
 
-	binding, err := (OAuthBindingDAO{}).GetByUserProviderContext(context.Background(), 42, "github")
+	binding, err := NewOAuthBindingDAO(db).GetByUserProviderContext(context.Background(), 42, "github")
 	if err != nil {
 		t.Fatalf("GetByUserProviderContext() error = %v", err)
 	}
@@ -55,14 +54,14 @@ func TestOAuthBindingDAOGetByUserProviderContext(t *testing.T) {
 }
 
 func TestOAuthBindingDAODeleteByUserProviderContextConstrainsCurrentUser(t *testing.T) {
-	mock := setupAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `oauth_bindings` WHERE user_id = ? AND provider = ?")).
 		WithArgs(42, "github").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	rows, err := (OAuthBindingDAO{}).DeleteByUserProviderContext(context.Background(), 42, "github")
+	rows, err := NewOAuthBindingDAO(db).DeleteByUserProviderContext(context.Background(), 42, "github")
 	if err != nil {
 		t.Fatalf("DeleteByUserProviderContext() error = %v", err)
 	}
@@ -72,13 +71,7 @@ func TestOAuthBindingDAODeleteByUserProviderContextConstrainsCurrentUser(t *test
 }
 
 func TestOAuthBindingDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `oauth_bindings` WHERE provider = ? AND provider_user_id = ? ORDER BY `oauth_bindings`.`id` LIMIT ?")).
 		WithArgs("github", "123", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "provider", "provider_user_id"}).

--- a/server/internal/dao/auth/permission_context_test.go
+++ b/server/internal/dao/auth/permission_context_test.go
@@ -7,30 +7,21 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
-	"gorm.io/driver/mysql"
-	"gorm.io/gorm"
 )
 
 func TestPermissionDAOGetUserPermissionsContextHonorsCanceledContext(t *testing.T) {
-	setupAuthPermissionContextTestDB(t)
+	db, _ := newAuthDAOTestDB(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&PermissionDAO{}).GetUserPermissionsContext(ctx, 7)
+	_, err := NewPermissionDAO(db).GetUserPermissionsContext(ctx, 7)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetUserPermissionsContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestPermissionDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT permissions.code FROM `users` JOIN user_roles ON users.id = user_roles.user_id JOIN roles ON user_roles.role_id = roles.id JOIN role_permissions ON roles.id = role_permissions.role_id JOIN permissions ON role_permissions.permission_id = permissions.id WHERE users.id = ?")).
 		WithArgs(uint(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"code"}).AddRow("dashboard.view"))
@@ -42,32 +33,4 @@ func TestPermissionDAOUsesInjectedDB(t *testing.T) {
 	if len(codes) != 1 || codes[0] != "dashboard.view" {
 		t.Fatalf("codes = %v, want dashboard.view", codes)
 	}
-}
-
-func setupAuthPermissionContextTestDB(t *testing.T) sqlmock.Sqlmock {
-	t.Helper()
-
-	oldDB := database.DB
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("open sqlmock db: %v", err)
-	}
-	db, err := gorm.Open(mysql.New(mysql.Config{
-		Conn:                      sqlDB,
-		SkipInitializeWithVersion: true,
-	}), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("open gorm sqlmock db: %v", err)
-	}
-
-	database.DB = db
-	t.Cleanup(func() {
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet database expectations: %v", err)
-		}
-		_ = sqlDB.Close()
-		database.DB = oldDB
-	})
-
-	return mock
 }

--- a/server/internal/dao/auth/user_test.go
+++ b/server/internal/dao/auth/user_test.go
@@ -7,19 +7,12 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestUserDAOGetUserByPhoneUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE phone = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs("13800000000", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "phone"}).AddRow(42, "alice", "13800000000"))
@@ -34,7 +27,7 @@ func TestUserDAOGetUserByPhoneUsesInjectedDB(t *testing.T) {
 }
 
 func TestUserDAOReplaceTOTPRecoveryCodesContext(t *testing.T) {
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	now := time.Date(2026, 5, 22, 9, 10, 0, 0, time.UTC)
 
 	mock.ExpectBegin()
@@ -51,7 +44,7 @@ func TestUserDAOReplaceTOTPRecoveryCodesContext(t *testing.T) {
 }
 
 func TestUserDAOListUnusedTOTPRecoveryCodesContext(t *testing.T) {
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `totp_recovery_codes` WHERE user_id = ? AND used_at IS NULL ORDER BY id ASC")).
 		WithArgs(uint(7)).
@@ -69,7 +62,7 @@ func TestUserDAOListUnusedTOTPRecoveryCodesContext(t *testing.T) {
 }
 
 func TestUserDAOMarkTOTPRecoveryCodeUsedContext(t *testing.T) {
-	db, mock := newInjectedAuthDAOTestDB(t)
+	db, mock := newAuthDAOTestDB(t)
 	now := time.Date(2026, 5, 22, 9, 12, 0, 0, time.UTC)
 
 	mock.ExpectBegin()
@@ -83,7 +76,9 @@ func TestUserDAOMarkTOTPRecoveryCodeUsedContext(t *testing.T) {
 	}
 }
 
-func newInjectedAuthDAOTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+// newAuthDAOTestDB returns a sqlmock-backed *gorm.DB for constructor
+// injection into auth DAOs. It never touches the global database.DB.
+func newAuthDAOTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
 	sqlDB, mock, err := sqlmock.New()

--- a/server/internal/dao/monitor/job_context_test.go
+++ b/server/internal/dao/monitor/job_context_test.go
@@ -7,29 +7,22 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestJobDAOGetJobByIDContextHonorsCanceledContext(t *testing.T) {
-	setupMonitorDAOTestDB(t)
+	db, _ := newMonitorDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := NewJobDAO().GetJobByIDContext(ctx, 1)
+	_, err := NewJobDAO(db).GetJobByIDContext(ctx, 1)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetJobByIDContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestJobDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedMonitorDAOTestDB(t)
+	db, mock := newMonitorDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `scheduled_jobs` WHERE `scheduled_jobs`.`id` = ? ORDER BY `scheduled_jobs`.`id` LIMIT ?")).
 		WithArgs(uint(42), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(42, "daily-report"))

--- a/server/internal/dao/monitor/job_ready_test.go
+++ b/server/internal/dao/monitor/job_ready_test.go
@@ -6,22 +6,26 @@ import (
 	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
-func TestJobDAOReadyReflectsDatabaseAvailability(t *testing.T) {
+func TestJobDAOReadyIsFalseWithoutInjectedDatabase(t *testing.T) {
+	// Ready() still falls back to the global database.DB until the fallback
+	// removal lands, so asserting false requires clearing the global. This is
+	// the only test allowed to keep a database.DB reference during the
+	// transition.
 	oldDB := database.DB
 	database.DB = nil
 	t.Cleanup(func() {
 		database.DB = oldDB
 	})
 
-	if NewJobDAO().Ready() {
-		t.Fatal("Ready() = true, want false when database is nil")
+	if (&JobDAO{}).Ready() {
+		t.Fatal("Ready() = true, want false when no database is injected")
 	}
 }
 
-func TestJobDAOReadyReturnsTrueWhenDatabaseIsConfigured(t *testing.T) {
-	setupMonitorDAOTestDB(t)
+func TestJobDAOReadyReturnsTrueWithInjectedDatabase(t *testing.T) {
+	db, _ := newMonitorDAOTestDB(t)
 
-	if !NewJobDAO().Ready() {
-		t.Fatal("Ready() = false, want true when database is configured")
+	if !NewJobDAO(db).Ready() {
+		t.Fatal("Ready() = false, want true when a database is injected")
 	}
 }

--- a/server/internal/dao/monitor/mysql_test.go
+++ b/server/internal/dao/monitor/mysql_test.go
@@ -8,19 +8,18 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestMySQLDAOGetNameValuesContext(t *testing.T) {
-	mock := setupMonitorDAOTestDB(t)
+	db, mock := newMonitorDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SHOW GLOBAL STATUS")).
 		WillReturnRows(sqlmock.NewRows([]string{"Variable_name", "Value"}).
 			AddRow("Uptime", "120").
 			AddRow("Questions", "240"))
 
-	values, err := NewMySQLDAO().GetNameValuesContext(context.Background(), "SHOW GLOBAL STATUS")
+	values, err := NewMySQLDAO(db).GetNameValuesContext(context.Background(), "SHOW GLOBAL STATUS")
 	if err != nil {
 		t.Fatalf("GetNameValuesContext() error = %v", err)
 	}
@@ -31,19 +30,19 @@ func TestMySQLDAOGetNameValuesContext(t *testing.T) {
 }
 
 func TestMySQLDAOGetVersionContextHonorsCanceledContext(t *testing.T) {
-	setupMonitorDAOTestDB(t)
+	db, _ := newMonitorDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := NewMySQLDAO().GetVersionContext(ctx)
+	_, err := NewMySQLDAO(db).GetVersionContext(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetVersionContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestMySQLDAOGetTableStatsContext(t *testing.T) {
-	mock := setupMonitorDAOTestDB(t)
+	db, mock := newMonitorDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*) AS table_count, COALESCE(SUM(data_length + index_length), 0) AS database_size
 		 FROM information_schema.tables
 		 WHERE table_schema = ?`)).
@@ -51,7 +50,7 @@ func TestMySQLDAOGetTableStatsContext(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"table_count", "database_size"}).
 			AddRow(12, 4096))
 
-	stats, err := NewMySQLDAO().GetTableStatsContext(context.Background(), "go_admin")
+	stats, err := NewMySQLDAO(db).GetTableStatsContext(context.Background(), "go_admin")
 	if err != nil {
 		t.Fatalf("GetTableStatsContext() error = %v", err)
 	}
@@ -61,27 +60,7 @@ func TestMySQLDAOGetTableStatsContext(t *testing.T) {
 }
 
 func TestMySQLDAOGetVersionContext(t *testing.T) {
-	mock := setupMonitorDAOTestDB(t)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
-		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("8.0.36"))
-
-	version, err := NewMySQLDAO().GetVersionContext(context.Background())
-	if err != nil {
-		t.Fatalf("GetVersionContext() error = %v", err)
-	}
-	if version != "8.0.36" {
-		t.Fatalf("version = %q, want 8.0.36", version)
-	}
-}
-
-func TestMySQLDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	db, mock := newInjectedMonitorDAOTestDB(t)
+	db, mock := newMonitorDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
 		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("8.0.36"))
 
@@ -94,53 +73,41 @@ func TestMySQLDAOUsesInjectedDB(t *testing.T) {
 	}
 }
 
-func setupMonitorDAOTestDB(t *testing.T) sqlmock.Sqlmock {
+func TestMySQLDAOUsesInjectedDB(t *testing.T) {
+	db, mock := newMonitorDAOTestDB(t)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("8.0.36"))
+
+	version, err := NewMySQLDAO(db).GetVersionContext(context.Background())
+	if err != nil {
+		t.Fatalf("GetVersionContext() error = %v", err)
+	}
+	if version != "8.0.36" {
+		t.Fatalf("version = %q, want 8.0.36", version)
+	}
+}
+
+// newMonitorDAOTestDB returns a sqlmock-backed *gorm.DB for constructor
+// injection into monitor DAOs. It never touches the global database.DB.
+func newMonitorDAOTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet database expectations: %v", err)
+		}
+		_ = sqlDB.Close()
+	})
 	db, err := gorm.Open(mysql.New(mysql.Config{
 		Conn:                      sqlDB,
 		SkipInitializeWithVersion: true,
 	}), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open gorm sqlmock db: %v", err)
-	}
-
-	database.DB = db
-	t.Cleanup(func() {
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet database expectations: %v", err)
-		}
-		_ = sqlDB.Close()
-		database.DB = oldDB
-	})
-
-	return mock
-}
-
-func newInjectedMonitorDAOTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
-	t.Helper()
-
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("open injected sqlmock db: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet injected database expectations: %v", err)
-		}
-		_ = sqlDB.Close()
-	})
-	db, err := gorm.Open(mysql.New(mysql.Config{
-		Conn:                      sqlDB,
-		SkipInitializeWithVersion: true,
-	}), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("open injected gorm sqlmock db: %v", err)
 	}
 	return db, mock
 }

--- a/server/internal/dao/system/audit_log_context_test.go
+++ b/server/internal/dao/system/audit_log_context_test.go
@@ -13,19 +13,18 @@ import (
 )
 
 func TestAuditLogDAOListLogsContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&AuditLogDAO{}).ListLogsContext(ctx, AuditLogListQuery{Page: 1, PageSize: 10})
+	_, err := NewAuditLogDAO(db).ListLogsContext(ctx, AuditLogListQuery{Page: 1, PageSize: 10})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListLogsContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestAuditLogDAOCreateLogContextUsesInjectedDB(t *testing.T) {
-	setupSystemDAOTestDB(t)
 	db, mock := newInjectedLogFileDAOTestDB(t)
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `audit_logs`")).
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/server/internal/dao/system/data_scope_test.go
+++ b/server/internal/dao/system/data_scope_test.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-admin-kit/server/internal/pkg/authz"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"github.com/go-admin-kit/server/internal/pkg/pagination"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestUserDAOGetUserListAppliesDepartmentScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `users` WHERE department_id IN (?,?)")).
 		WithArgs(uint(10), uint(11)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
@@ -24,7 +23,7 @@ func TestUserDAOGetUserListAppliesDepartmentScope(t *testing.T) {
 		WithArgs(uint(10), uint(11), 10).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	users, total, err := (&UserDAO{}).GetUserListContext(
+	users, total, err := NewUserDAO(db).GetUserListContext(
 		context.Background(),
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		"",
@@ -40,12 +39,12 @@ func TestUserDAOGetUserListAppliesDepartmentScope(t *testing.T) {
 }
 
 func TestUserDAOGetUserListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&UserDAO{}).GetUserListContext(
+	_, _, err := NewUserDAO(db).GetUserListContext(
 		ctx,
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		"",
@@ -58,12 +57,12 @@ func TestUserDAOGetUserListContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestFileDAOGetByIDInScopeAppliesOwnerDepartmentScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `files` WHERE id = ? AND user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?)) ORDER BY `files`.`id` LIMIT ?")).
 		WithArgs(uint(99), uint(20), uint(21), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	_, err := (&FileDAO{}).GetByIDInScopeContext(
+	_, err := NewFileDAO(db).GetByIDInScopeContext(
 		context.Background(),
 		99,
 		authz.UserDataScope{Scope: authz.DataScopeCustom, DepartmentIDs: []uint{20, 21}},
@@ -74,12 +73,12 @@ func TestFileDAOGetByIDInScopeAppliesOwnerDepartmentScope(t *testing.T) {
 }
 
 func TestFileDAOGetByHashInScopeAppliesSelfScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `files` WHERE hash = ? AND user_id = ? ORDER BY `files`.`id` LIMIT ?")).
 		WithArgs("abc123", uint(7), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	_, err := (&FileDAO{}).GetByHashInScopeContext(
+	_, err := NewFileDAO(db).GetByHashInScopeContext(
 		context.Background(),
 		"abc123",
 		authz.UserDataScope{Scope: authz.DataScopeSelf, UserID: 7},
@@ -90,14 +89,14 @@ func TestFileDAOGetByHashInScopeAppliesSelfScope(t *testing.T) {
 }
 
 func TestFileDAOGetListAppliesNoScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `files` WHERE 1 = 0")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `files` WHERE 1 = 0 ORDER BY created_at DESC LIMIT ?")).
 		WithArgs(10).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	files, total, err := (&FileDAO{}).GetListContext(
+	files, total, err := NewFileDAO(db).GetListContext(
 		context.Background(),
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		nil,
@@ -116,7 +115,7 @@ func TestFileDAOGetListAppliesNoScope(t *testing.T) {
 }
 
 func TestFileDAOGetStatsInScopeAppliesOwnerDepartmentScopeToBothAggregates(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) as count, COALESCE(SUM(file_size), 0) as total_size FROM `files` WHERE user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?))")).
 		WithArgs(uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"count", "total_size"}).AddRow(3, 2048))
@@ -124,7 +123,7 @@ func TestFileDAOGetStatsInScopeAppliesOwnerDepartmentScopeToBothAggregates(t *te
 		WithArgs(uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"file_type", "count", "size"}).AddRow("image", 2, 1024).AddRow("doc", 1, 1024))
 
-	stats, err := (&FileDAO{}).GetStatsInScopeContext(
+	stats, err := NewFileDAO(db).GetStatsInScopeContext(
 		context.Background(),
 		nil,
 		authz.UserDataScope{Scope: authz.DataScopeDepartment, DepartmentIDs: []uint{20, 21}},
@@ -141,7 +140,7 @@ func TestFileDAOGetStatsInScopeAppliesOwnerDepartmentScopeToBothAggregates(t *te
 }
 
 func TestLoginLogDAOGetListAppliesDepartmentScopeAndFilters(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	status := int8(1)
 	loginType := int8(2)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `login_logs` WHERE username LIKE ? AND ip LIKE ? AND status = ? AND login_type = ? AND user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?))")).
@@ -151,7 +150,7 @@ func TestLoginLogDAOGetListAppliesDepartmentScopeAndFilters(t *testing.T) {
 		WithArgs("%alice%", "%10.%", status, loginType, uint(20), uint(21), 10).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	logs, total, err := (&LoginLogDAO{}).GetListContext(
+	logs, total, err := NewLoginLogDAO(db).GetListContext(
 		context.Background(),
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		nil,
@@ -172,7 +171,7 @@ func TestLoginLogDAOGetListAppliesDepartmentScopeAndFilters(t *testing.T) {
 }
 
 func TestLoginLogDAOGetStatsInScopeAppliesDepartmentScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `login_logs` WHERE user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?))")).
 		WithArgs(uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(5))
@@ -189,7 +188,7 @@ func TestLoginLogDAOGetStatsInScopeAppliesDepartmentScope(t *testing.T) {
 		WithArgs(uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"browser", "count"}).AddRow("Chrome", 4))
 
-	stats, err := (&LoginLogDAO{}).GetStatsInScopeContext(
+	stats, err := NewLoginLogDAO(db).GetStatsInScopeContext(
 		context.Background(),
 		nil,
 		nil,
@@ -204,7 +203,7 @@ func TestLoginLogDAOGetStatsInScopeAppliesDepartmentScope(t *testing.T) {
 }
 
 func TestLoginLogDAOGetLoginTrendInScopeAppliesDepartmentScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `login_logs` WHERE (created_at >= ? AND created_at < ?) AND user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?))")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(5))
@@ -212,7 +211,7 @@ func TestLoginLogDAOGetLoginTrendInScopeAppliesDepartmentScope(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(4))
 
-	trend, err := (&LoginLogDAO{}).GetLoginTrendInScopeContext(
+	trend, err := NewLoginLogDAO(db).GetLoginTrendInScopeContext(
 		context.Background(),
 		1,
 		authz.UserDataScope{Scope: authz.DataScopeDepartment, DepartmentIDs: []uint{20, 21}},
@@ -226,7 +225,7 @@ func TestLoginLogDAOGetLoginTrendInScopeAppliesDepartmentScope(t *testing.T) {
 }
 
 func TestOperationLogDAOGetLogListAppliesSelfScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `operation_logs` WHERE user_id = ?")).
 		WithArgs(uint(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
@@ -234,7 +233,7 @@ func TestOperationLogDAOGetLogListAppliesSelfScope(t *testing.T) {
 		WithArgs(uint(7), 10).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	logs, total, err := (&OperationLogDAO{}).GetLogListContext(
+	logs, total, err := NewOperationLogDAO(db).GetLogListContext(
 		context.Background(),
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		nil,
@@ -260,12 +259,12 @@ func TestOperationLogDAOGetLogListAppliesSelfScope(t *testing.T) {
 }
 
 func TestOperationLogDAOGetLogByIDInScopeAppliesDepartmentScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `operation_logs` WHERE id = ? AND user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?)) ORDER BY `operation_logs`.`id` LIMIT ?")).
 		WithArgs(uint(88), uint(20), uint(21), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	_, err := (&OperationLogDAO{}).GetLogByIDInScopeContext(
+	_, err := NewOperationLogDAO(db).GetLogByIDInScopeContext(
 		context.Background(),
 		88,
 		authz.UserDataScope{Scope: authz.DataScopeDepartment, DepartmentIDs: []uint{20, 21}},
@@ -276,7 +275,7 @@ func TestOperationLogDAOGetLogByIDInScopeAppliesDepartmentScope(t *testing.T) {
 }
 
 func TestOperationLogDAOGetLogStatsInScopeAppliesDepartmentScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `operation_logs` WHERE user_id IN (SELECT `id` FROM `users` WHERE department_id IN (?,?))")).
 		WithArgs(uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(6))
@@ -290,7 +289,7 @@ func TestOperationLogDAOGetLogStatsInScopeAppliesDepartmentScope(t *testing.T) {
 		WithArgs(uint(20), uint(21)).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(2))
 
-	stats, err := (&OperationLogDAO{}).GetLogStatsInScopeContext(
+	stats, err := NewOperationLogDAO(db).GetLogStatsInScopeContext(
 		context.Background(),
 		nil,
 		nil,
@@ -305,14 +304,14 @@ func TestOperationLogDAOGetLogStatsInScopeAppliesDepartmentScope(t *testing.T) {
 }
 
 func TestOperationLogDAODeleteLogsBeforeInScopeAppliesSelfScope(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `operation_logs` WHERE created_at < ? AND user_id = ?")).
 		WithArgs(sqlmock.AnyArg(), uint(7)).
 		WillReturnResult(sqlmock.NewResult(0, 3))
 	mock.ExpectCommit()
 
-	deleted, err := (&OperationLogDAO{}).DeleteLogsBeforeInScopeContext(
+	deleted, err := NewOperationLogDAO(db).DeleteLogsBeforeInScopeContext(
 		context.Background(),
 		timeNowForOperationLogDeleteTest(),
 		authz.UserDataScope{Scope: authz.DataScopeSelf, UserID: 7},
@@ -329,10 +328,9 @@ func timeNowForOperationLogDeleteTest() time.Time {
 	return time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
 }
 
-func setupSystemDAOTestDB(t *testing.T) sqlmock.Sqlmock {
+func setupSystemDAOTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -348,14 +346,12 @@ func setupSystemDAOTestDB(t *testing.T) sqlmock.Sqlmock {
 		t.Fatalf("register data scope plugin: %v", err)
 	}
 
-	database.DB = db
 	t.Cleanup(func() {
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
 
-	return mock
+	return db, mock
 }

--- a/server/internal/dao/system/department_context_test.go
+++ b/server/internal/dao/system/department_context_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
@@ -25,12 +24,6 @@ func TestDepartmentDAOGetTreeContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestDepartmentDAOGetAllUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	db, mock := newInjectedDepartmentMenuDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `departments` ORDER BY parent_id ASC, sort ASC, created_at ASC")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "code"}).AddRow(7, "Engineering", "eng"))

--- a/server/internal/dao/system/dict_context_test.go
+++ b/server/internal/dao/system/dict_context_test.go
@@ -7,19 +7,18 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"github.com/go-admin-kit/server/internal/pkg/pagination"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestDictDAOGetTypeListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&DictDAO{}).GetTypeListContext(ctx, pagination.PageRequest{Page: 1, PageSize: 10}, "", nil)
+	_, _, err := NewDictDAO(db).GetTypeListContext(ctx, pagination.PageRequest{Page: 1, PageSize: 10}, "", nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetTypeListContext() error = %v, want context.Canceled", err)
 	}
@@ -27,11 +26,6 @@ func TestDictDAOGetTypeListContextHonorsCanceledContext(t *testing.T) {
 
 func TestDictDAOUsesInjectedDB(t *testing.T) {
 	db, mock := newInjectedDictNoticeSeedDAOTestDB(t)
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `dict_types` WHERE code = ? ORDER BY `dict_types`.`id` LIMIT ?")).
 		WithArgs("gender", 1).

--- a/server/internal/dao/system/file_context_test.go
+++ b/server/internal/dao/system/file_context_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestFileDAOGetListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&FileDAO{}).GetListContext(
+	_, _, err := NewFileDAO(db).GetListContext(
 		ctx,
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		nil,
@@ -33,7 +33,6 @@ func TestFileDAOGetListContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestFileDAOGetByHashContextUsesInjectedDB(t *testing.T) {
-	setupSystemDAOTestDB(t)
 	db, mock := newInjectedLogFileDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `files` WHERE hash = ? ORDER BY `files`.`id` LIMIT ?")).
 		WithArgs("abc123", 1).
@@ -50,7 +49,6 @@ func TestFileDAOGetByHashContextUsesInjectedDB(t *testing.T) {
 }
 
 func TestFileDAOCountByPathExcludingIDUsesInjectedDB(t *testing.T) {
-	setupSystemDAOTestDB(t)
 	db, mock := newInjectedLogFileDAOTestDB(t)
 	dao := NewFileDAO(db)
 

--- a/server/internal/dao/system/login_log_context_test.go
+++ b/server/internal/dao/system/login_log_context_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestLoginLogDAOGetListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&LoginLogDAO{}).GetListContext(
+	_, _, err := NewLoginLogDAO(db).GetListContext(
 		ctx,
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		nil,
@@ -35,7 +35,6 @@ func TestLoginLogDAOGetListContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestLoginLogDAOGetByIDContextUsesInjectedDB(t *testing.T) {
-	setupSystemDAOTestDB(t)
 	db, mock := newInjectedLogFileDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `login_logs` WHERE `login_logs`.`id` = ? ORDER BY `login_logs`.`id` LIMIT ?")).
 		WithArgs(uint(9), 1).

--- a/server/internal/dao/system/menu_context_test.go
+++ b/server/internal/dao/system/menu_context_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestMenuDAOGetMenuTreeContextHonorsCanceledContext(t *testing.T) {
@@ -23,12 +22,6 @@ func TestMenuDAOGetMenuTreeContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestMenuDAOGetMenuTreeUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	db, mock := newInjectedDepartmentMenuDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `menus` ORDER BY parent_id ASC, sort ASC, created_at ASC")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "title", "parent_id"}).AddRow(9, "dashboard", "Dashboard", 0))

--- a/server/internal/dao/system/menu_seed_test.go
+++ b/server/internal/dao/system/menu_seed_test.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-admin-kit/server/internal/model"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestMenuSeedDAOInsertDefaultMenusWhenTableIsEmpty(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `menus`").
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
@@ -23,7 +22,7 @@ func TestMenuSeedDAOInsertDefaultMenusWhenTableIsEmpty(t *testing.T) {
 	mock.ExpectCommit()
 
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
-	count, err := (&MenuSeedDAO{}).BootstrapDefaultMenusContext(context.Background(), []model.Menu{
+	count, err := NewMenuSeedDAO(db).BootstrapDefaultMenusContext(context.Background(), []model.Menu{
 		{ID: 1, Name: "dashboard", Title: "Dashboard"},
 		{ID: 2, Name: "system", Title: "System"},
 	}, now)
@@ -36,12 +35,12 @@ func TestMenuSeedDAOInsertDefaultMenusWhenTableIsEmpty(t *testing.T) {
 }
 
 func TestMenuSeedDAOBootstrapDefaultMenusContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&MenuSeedDAO{}).BootstrapDefaultMenusContext(ctx, []model.Menu{
+	_, err := NewMenuSeedDAO(db).BootstrapDefaultMenusContext(ctx, []model.Menu{
 		{ID: 1, Name: "dashboard", Title: "Dashboard"},
 	}, time.Now())
 	if !errors.Is(err, context.Canceled) {
@@ -50,13 +49,13 @@ func TestMenuSeedDAOBootstrapDefaultMenusContextHonorsCanceledContext(t *testing
 }
 
 func TestMenuSeedDAOSkipsWhenMenusExist(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `menus`").
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(3))
 	mock.ExpectCommit()
 
-	count, err := (&MenuSeedDAO{}).BootstrapDefaultMenusContext(context.Background(), []model.Menu{
+	count, err := NewMenuSeedDAO(db).BootstrapDefaultMenusContext(context.Background(), []model.Menu{
 		{ID: 1, Name: "dashboard", Title: "Dashboard"},
 	}, time.Now())
 	if err != nil {
@@ -69,11 +68,6 @@ func TestMenuSeedDAOSkipsWhenMenusExist(t *testing.T) {
 
 func TestMenuSeedDAOUsesInjectedDB(t *testing.T) {
 	db, mock := newInjectedDictNoticeSeedDAOTestDB(t)
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `menus`").

--- a/server/internal/dao/system/notice_context_test.go
+++ b/server/internal/dao/system/notice_context_test.go
@@ -7,17 +7,16 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"github.com/go-admin-kit/server/internal/pkg/pagination"
 )
 
 func TestNoticeDAOGetListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&NoticeDAO{}).GetListContext(ctx, pagination.PageRequest{Page: 1, PageSize: 10}, nil, nil, "")
+	_, _, err := NewNoticeDAO(db).GetListContext(ctx, pagination.PageRequest{Page: 1, PageSize: 10}, nil, nil, "")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetListContext() error = %v, want context.Canceled", err)
 	}
@@ -25,11 +24,6 @@ func TestNoticeDAOGetListContextHonorsCanceledContext(t *testing.T) {
 
 func TestNoticeDAOUsesInjectedDB(t *testing.T) {
 	db, mock := newInjectedDictNoticeSeedDAOTestDB(t)
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `notices` WHERE `notices`.`id` = ? ORDER BY `notices`.`id` LIMIT ?")).
 		WithArgs(uint(9), 1).

--- a/server/internal/dao/system/operation_log_context_test.go
+++ b/server/internal/dao/system/operation_log_context_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestOperationLogDAOGetLogListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&OperationLogDAO{}).GetLogListContext(
+	_, _, err := NewOperationLogDAO(db).GetLogListContext(
 		ctx,
 		pagination.PageRequest{Page: 1, PageSize: 10},
 		nil,
@@ -40,7 +40,6 @@ func TestOperationLogDAOGetLogListContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestOperationLogDAOGetLogByIDContextUsesInjectedDB(t *testing.T) {
-	setupSystemDAOTestDB(t)
 	db, mock := newInjectedLogFileDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `operation_logs` WHERE `operation_logs`.`id` = ? ORDER BY `operation_logs`.`id` LIMIT ?")).
 		WithArgs(uint(11), 1).

--- a/server/internal/dao/system/permission_cache_test.go
+++ b/server/internal/dao/system/permission_cache_test.go
@@ -8,16 +8,9 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestPermissionCacheDAOFindUserIDsByRoleIDsUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	db, mock := newInjectedRBACDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT `user_id` FROM `user_roles` WHERE role_id IN (?)")).
 		WithArgs(uint(9)).
@@ -33,14 +26,14 @@ func TestPermissionCacheDAOFindUserIDsByRoleIDsUsesInjectedDB(t *testing.T) {
 }
 
 func TestPermissionCacheDAOFindUserIDsByRoleIDs(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT `user_id` FROM `user_roles` WHERE role_id IN (?,?)")).
 		WithArgs(uint(2), uint(3)).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).
 			AddRow(uint(10)).
 			AddRow(uint(11)))
 
-	userIDs, err := (&PermissionCacheDAO{}).FindUserIDsByRoleIDsContext(context.Background(), []uint{2, 3})
+	userIDs, err := NewPermissionCacheDAO(db).FindUserIDsByRoleIDsContext(context.Background(), []uint{2, 3})
 	if err != nil {
 		t.Fatalf("FindUserIDsByRoleIDsContext() error = %v", err)
 	}
@@ -50,26 +43,26 @@ func TestPermissionCacheDAOFindUserIDsByRoleIDs(t *testing.T) {
 }
 
 func TestPermissionCacheDAOFindUserIDsByRoleIDsContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&PermissionCacheDAO{}).FindUserIDsByRoleIDsContext(ctx, []uint{2})
+	_, err := NewPermissionCacheDAO(db).FindUserIDsByRoleIDsContext(ctx, []uint{2})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("FindUserIDsByRoleIDsContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestPermissionCacheDAOFindRoleIDsByPermissionIDs(t *testing.T) {
-	mock := setupSystemDAOTestDB(t)
+	db, mock := setupSystemDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT `role_id` FROM `role_permissions` WHERE permission_id IN (?,?)")).
 		WithArgs(uint(5), uint(6)).
 		WillReturnRows(sqlmock.NewRows([]string{"role_id"}).
 			AddRow(uint(20)).
 			AddRow(uint(21)))
 
-	roleIDs, err := (&PermissionCacheDAO{}).FindRoleIDsByPermissionIDsContext(context.Background(), []uint{5, 6})
+	roleIDs, err := NewPermissionCacheDAO(db).FindRoleIDsByPermissionIDsContext(context.Background(), []uint{5, 6})
 	if err != nil {
 		t.Fatalf("FindRoleIDsByPermissionIDsContext() error = %v", err)
 	}
@@ -79,9 +72,10 @@ func TestPermissionCacheDAOFindRoleIDsByPermissionIDs(t *testing.T) {
 }
 
 func TestPermissionCacheDAOEmptyInputsSkipDatabase(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
+	dao := NewPermissionCacheDAO(db)
 
-	userIDs, err := (&PermissionCacheDAO{}).FindUserIDsByRoleIDsContext(context.Background(), nil)
+	userIDs, err := dao.FindUserIDsByRoleIDsContext(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("FindUserIDsByRoleIDsContext(nil) error = %v", err)
 	}
@@ -89,7 +83,7 @@ func TestPermissionCacheDAOEmptyInputsSkipDatabase(t *testing.T) {
 		t.Fatalf("userIDs = %#v, want nil", userIDs)
 	}
 
-	roleIDs, err := (&PermissionCacheDAO{}).FindRoleIDsByPermissionIDsContext(context.Background(), nil)
+	roleIDs, err := dao.FindRoleIDsByPermissionIDsContext(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("FindRoleIDsByPermissionIDsContext(nil) error = %v", err)
 	}

--- a/server/internal/dao/system/permission_context_test.go
+++ b/server/internal/dao/system/permission_context_test.go
@@ -7,16 +7,9 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestPermissionManageDAOGetPermissionTreeUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	db, mock := newInjectedRBACDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `permissions` ORDER BY parent_id ASC, created_at ASC")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "code", "type", "parent_id"}).
@@ -33,12 +26,12 @@ func TestPermissionManageDAOGetPermissionTreeUsesInjectedDB(t *testing.T) {
 }
 
 func TestPermissionManageDAOGetPermissionTreeContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&PermissionManageDAO{}).GetPermissionTreeContext(ctx)
+	_, err := NewPermissionManageDAO(db).GetPermissionTreeContext(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetPermissionTreeContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/dao/system/role_context_test.go
+++ b/server/internal/dao/system/role_context_test.go
@@ -7,19 +7,12 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"github.com/go-admin-kit/server/internal/pkg/pagination"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestRoleDAOGetRoleByCodeUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	db, mock := newInjectedRBACDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `roles` WHERE code = ? ORDER BY `roles`.`id` LIMIT ?")).
 		WithArgs("admin", 1).
@@ -35,12 +28,12 @@ func TestRoleDAOGetRoleByCodeUsesInjectedDB(t *testing.T) {
 }
 
 func TestRoleDAOGetRoleListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemDAOTestDB(t)
+	db, _ := setupSystemDAOTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&RoleDAO{}).GetRoleListContext(ctx, pagination.PageRequest{Page: 1, PageSize: 10}, "")
+	_, _, err := NewRoleDAO(db).GetRoleListContext(ctx, pagination.PageRequest{Page: 1, PageSize: 10}, "")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetRoleListContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/dao/system/user_injection_test.go
+++ b/server/internal/dao/system/user_injection_test.go
@@ -7,19 +7,12 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-admin-kit/server/internal/pkg/authz"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"github.com/go-admin-kit/server/internal/pkg/pagination"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestUserDAOGetUserListUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	db, mock := newInjectedSystemUserTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `users`")).
 		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))

--- a/server/internal/dao/user_test.go
+++ b/server/internal/dao/user_test.go
@@ -7,18 +7,17 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestUserDAOGetUserByUsernameUsesSharedQuery(t *testing.T) {
-	mock := setupDAOTestDB(t)
+	db, mock := newDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE username = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs("alice", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username"}).AddRow(42, "alice"))
 
-	user, err := (&UserDAO{}).GetUserByUsernameContext(context.Background(), "alice")
+	user, err := NewUserDAO(db).GetUserByUsernameContext(context.Background(), "alice")
 	if err != nil {
 		t.Fatalf("GetUserByUsernameContext() error = %v", err)
 	}
@@ -28,52 +27,30 @@ func TestUserDAOGetUserByUsernameUsesSharedQuery(t *testing.T) {
 }
 
 func TestUserDAOGetUserWithRolesReturnsNotFound(t *testing.T) {
-	mock := setupDAOTestDB(t)
+	db, mock := newDAOTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE `users`.`id` = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs(uint(99), 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	_, err := (&UserDAO{}).GetUserWithRolesContext(context.Background(), 99)
+	_, err := NewUserDAO(db).GetUserWithRolesContext(context.Background(), 99)
 	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Fatalf("GetUserWithRolesContext() error = %v, want record not found", err)
 	}
 }
 
 func TestUserDAOGetUserWithRolesContextHonorsCanceledContext(t *testing.T) {
-	setupDAOTestDB(t)
+	db, _ := newDAOTestDB(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&UserDAO{}).GetUserWithRolesContext(ctx, 99)
+	_, err := NewUserDAO(db).GetUserWithRolesContext(ctx, 99)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetUserWithRolesContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestUserDAOUsesInjectedDB(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("open injected sqlmock db: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet injected database expectations: %v", err)
-		}
-		_ = sqlDB.Close()
-	})
-	db, err := gorm.Open(mysql.New(mysql.Config{
-		Conn:                      sqlDB,
-		SkipInitializeWithVersion: true,
-	}), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("open injected gorm db: %v", err)
-	}
+	db, mock := newDAOTestDB(t)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE username = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs("alice", 1).
@@ -88,14 +65,21 @@ func TestUserDAOUsesInjectedDB(t *testing.T) {
 	}
 }
 
-func setupDAOTestDB(t *testing.T) sqlmock.Sqlmock {
+// newDAOTestDB returns a sqlmock-backed *gorm.DB for constructor injection.
+// It never touches the global database.DB.
+func newDAOTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet database expectations: %v", err)
+		}
+		_ = sqlDB.Close()
+	})
 	db, err := gorm.Open(mysql.New(mysql.Config{
 		Conn:                      sqlDB,
 		SkipInitializeWithVersion: true,
@@ -103,15 +87,5 @@ func setupDAOTestDB(t *testing.T) sqlmock.Sqlmock {
 	if err != nil {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
-
-	database.DB = db
-	t.Cleanup(func() {
-		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet database expectations: %v", err)
-		}
-		_ = sqlDB.Close()
-		database.DB = oldDB
-	})
-
-	return mock
+	return db, mock
 }

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -5,12 +5,10 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	authDAO "github.com/go-admin-kit/server/internal/dao/auth"
 	"github.com/go-admin-kit/server/internal/pkg/cache"
 	"github.com/go-admin-kit/server/internal/pkg/consoleauth"
 	"github.com/go-admin-kit/server/internal/pkg/jwt"
 	"github.com/go-admin-kit/server/internal/pkg/response"
-	authSvc "github.com/go-admin-kit/server/internal/service/auth"
 )
 
 // AuthMiddleware validates an access token and stores the actor in the request context.
@@ -57,13 +55,18 @@ func AuthMiddleware() gin.HandlerFunc {
 			return
 		}
 		if tokenSource == consoleauth.TokenSourceCookie {
-			if _, err := (authSvc.ConsoleSessionService{}).ValidateActiveSessionContext(c.Request.Context(), claims.ID, claims.Username); err != nil {
+			deps := currentAuthDeps()
+			if deps.ConsoleSessions == nil || deps.Users == nil {
 				response.UnauthorizedWithCode(c, response.ErrorCodeConsoleLoginRequired, "Console login required")
 				c.Abort()
 				return
 			}
-			userDAO := authDAO.UserDAO{}
-			user, err := userDAO.GetUserWithRolesContext(c.Request.Context(), claims.UserID)
+			if _, err := deps.ConsoleSessions.ValidateActiveSessionContext(c.Request.Context(), claims.ID, claims.Username); err != nil {
+				response.UnauthorizedWithCode(c, response.ErrorCodeConsoleLoginRequired, "Console login required")
+				c.Abort()
+				return
+			}
+			user, err := deps.Users.GetUserWithRolesContext(c.Request.Context(), claims.UserID)
 			if err != nil || user.Status != 1 {
 				response.UnauthorizedWithCode(c, response.ErrorCodeConsoleLoginRequired, "Console login required")
 				c.Abort()
@@ -89,8 +92,13 @@ func RoleMiddleware(requiredRoles ...string) gin.HandlerFunc {
 			return
 		}
 
-		userDAO := authDAO.UserDAO{}
-		user, err := userDAO.GetUserWithRolesContext(c.Request.Context(), userID.(uint))
+		users := currentAuthDeps().Users
+		if users == nil {
+			response.Forbidden(c, "failed to get user roles")
+			c.Abort()
+			return
+		}
+		user, err := users.GetUserWithRolesContext(c.Request.Context(), userID.(uint))
 		if err != nil {
 			response.Forbidden(c, "failed to get user roles")
 			c.Abort()
@@ -138,8 +146,13 @@ func PermissionMiddleware(requiredPermissions ...string) gin.HandlerFunc {
 		cacheService := cache.NewCacheService()
 		permissions, err := cacheService.GetUserPermissionsContext(c.Request.Context(), userID.(uint))
 		if err != nil || len(permissions) == 0 {
-			permissionDAO := authDAO.PermissionDAO{}
-			permissions, err = permissionDAO.GetUserPermissionsContext(c.Request.Context(), userID.(uint))
+			store := currentAuthDeps().Permissions
+			if store == nil {
+				response.Forbidden(c, "failed to get user permissions")
+				c.Abort()
+				return
+			}
+			permissions, err = store.GetUserPermissionsContext(c.Request.Context(), userID.(uint))
 			if err != nil {
 				response.Forbidden(c, "failed to get user permissions")
 				c.Abort()
@@ -174,8 +187,11 @@ func hasAnyRequiredPermission(grantedPermissions []string, requiredPermissions [
 }
 
 func hasRoleContext(ctx context.Context, userID uint, roleCodes ...string) bool {
-	userDAO := authDAO.UserDAO{}
-	user, err := userDAO.GetUserWithRolesContext(ctx, userID)
+	users := currentAuthDeps().Users
+	if users == nil {
+		return false
+	}
+	user, err := users.GetUserWithRolesContext(ctx, userID)
 	if err != nil {
 		return false
 	}

--- a/server/internal/middleware/dependencies.go
+++ b/server/internal/middleware/dependencies.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-admin-kit/server/internal/model"
+)
+
+// AuthUserStore loads users with roles for auth decisions.
+type AuthUserStore interface {
+	GetUserWithRolesContext(ctx context.Context, id uint) (*model.User, error)
+}
+
+// AuthPermissionStore loads permission codes for a user.
+type AuthPermissionStore interface {
+	GetUserPermissionsContext(ctx context.Context, userID uint) ([]string, error)
+}
+
+// ConsoleSessionValidator validates active console cookie sessions.
+type ConsoleSessionValidator interface {
+	ValidateActiveSessionContext(ctx context.Context, sessionID, username string) (*model.ConsoleSession, error)
+}
+
+// AuthMiddlewareDependencies groups the persistence used by auth middlewares.
+type AuthMiddlewareDependencies struct {
+	Users           AuthUserStore
+	Permissions     AuthPermissionStore
+	ConsoleSessions ConsoleSessionValidator
+}
+
+var (
+	authDepsMu sync.RWMutex
+	authDeps   AuthMiddlewareDependencies
+)
+
+// SetAuthMiddlewareDependencies installs the persistence behind the auth
+// middlewares and returns a restore function. Middlewares read the current
+// dependencies per request, so wiring only needs to happen before the first
+// request is served.
+func SetAuthMiddlewareDependencies(deps AuthMiddlewareDependencies) func() {
+	authDepsMu.Lock()
+	previous := authDeps
+	authDeps = deps
+	authDepsMu.Unlock()
+
+	return func() {
+		authDepsMu.Lock()
+		authDeps = previous
+		authDepsMu.Unlock()
+	}
+}
+
+func currentAuthDeps() AuthMiddlewareDependencies {
+	authDepsMu.RLock()
+	defer authDepsMu.RUnlock()
+	return authDeps
+}

--- a/server/internal/middleware/operation_log.go
+++ b/server/internal/middleware/operation_log.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-admin-kit/server/internal/model"
-	"github.com/go-admin-kit/server/internal/service/system"
 )
 
 // Operation module mapping.
@@ -206,13 +205,17 @@ const operationLogWriteTimeout = 2 * time.Second
 
 var logChan = make(chan *model.OperationLog, logChanBufferSize)
 
-type operationLogRecorder interface {
+// OperationLogRecorder persists operation logs queued by the middleware.
+type OperationLogRecorder interface {
 	RecordContext(context.Context, *model.OperationLog) error
 }
 
-// StartOperationLogProcessor starts the background operation log processor.
-func StartOperationLogProcessor(ctx context.Context) <-chan struct{} {
-	return processLogs(ctx, logChan, &system.OperationLogService{}, operationLogWriteTimeout)
+type operationLogRecorder = OperationLogRecorder
+
+// StartOperationLogProcessor starts the background operation log processor
+// backed by the injected recorder.
+func StartOperationLogProcessor(ctx context.Context, recorder OperationLogRecorder) <-chan struct{} {
+	return processLogs(ctx, logChan, recorder, operationLogWriteTimeout)
 }
 
 // processLogs persists queued operation logs until ctx is canceled.

--- a/server/internal/pkg/authz/data_scope.go
+++ b/server/internal/pkg/authz/data_scope.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-admin-kit/server/internal/dao/auth"
 	"github.com/go-admin-kit/server/internal/model"
 	"github.com/go-admin-kit/server/internal/pkg/database"
 	redisstore "github.com/go-admin-kit/server/internal/pkg/redis"
@@ -70,7 +69,15 @@ func NewDataScopeResolverWithCache(store DataScopeStore, cache DepartmentTreeCac
 	return &DataScopeResolver{store: store, cache: cache}
 }
 
-type databaseDataScopeStore struct{}
+type databaseDataScopeStore struct {
+	db *gorm.DB
+}
+
+// NewDatabaseDataScopeStore builds the default gorm-backed DataScopeStore
+// from an injected database handle.
+func NewDatabaseDataScopeStore(db *gorm.DB) DataScopeStore {
+	return databaseDataScopeStore{db: db}
+}
 
 type layeredDepartmentTreeCache struct {
 	mu        sync.RWMutex
@@ -219,8 +226,11 @@ func ResolveUserDataScopeFromContext(c *gin.Context) (UserDataScope, error) {
 		ctx = c.Request.Context()
 	}
 
-	userDAO := auth.UserDAO{}
-	user, err := userDAO.GetUserWithRolesContext(ctx, uid)
+	users := currentPersistence().Users
+	if users == nil {
+		return UserDataScope{Scope: DataScopeNone}, ErrPersistenceNotConfigured
+	}
+	user, err := users.GetUserWithRolesContext(ctx, uid)
 	if err != nil {
 		return UserDataScope{Scope: DataScopeNone}, err
 	}
@@ -569,6 +579,9 @@ func (r *DataScopeResolver) dataScopeStore() DataScopeStore {
 	if r != nil && r.store != nil {
 		return r.store
 	}
+	if store := currentPersistence().DataScope; store != nil {
+		return store
+	}
 	return databaseDataScopeStore{}
 }
 
@@ -579,25 +592,33 @@ func (r *DataScopeResolver) departmentTreeCache() DepartmentTreeCache {
 	return defaultDepartmentTreeCache
 }
 
-func (databaseDataScopeStore) ListDepartments(ctx context.Context) ([]model.Department, error) {
+func (s databaseDataScopeStore) ListDepartments(ctx context.Context) ([]model.Department, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
+	db := s.db
+	if db == nil {
+		db = database.DB
+	}
 	var depts []model.Department
-	if err := database.DB.WithContext(ctx).Model(&model.Department{}).Select("id", "parent_id").Find(&depts).Error; err != nil {
+	if err := db.WithContext(ctx).Model(&model.Department{}).Select("id", "parent_id").Find(&depts).Error; err != nil {
 		return nil, err
 	}
 	return depts, nil
 }
 
-func (databaseDataScopeStore) ListRoleDataScopeDepartmentIDs(ctx context.Context, roleIDs []uint) ([]uint, error) {
+func (s databaseDataScopeStore) ListRoleDataScopeDepartmentIDs(ctx context.Context, roleIDs []uint) ([]uint, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
+	db := s.db
+	if db == nil {
+		db = database.DB
+	}
 	var relations []model.RoleDataScopeDepartment
-	if err := database.DB.WithContext(ctx).
+	if err := db.WithContext(ctx).
 		Model(&model.RoleDataScopeDepartment{}).
 		Select("department_id").
 		Where("role_id IN ?", roleIDs).

--- a/server/internal/pkg/authz/data_scope_cache_test.go
+++ b/server/internal/pkg/authz/data_scope_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	miniredis "github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
+	authdao "github.com/go-admin-kit/server/internal/dao/auth"
 	"github.com/go-admin-kit/server/internal/model"
 	"github.com/go-admin-kit/server/internal/pkg/database"
 	redisstore "github.com/go-admin-kit/server/internal/pkg/redis"
@@ -391,7 +392,13 @@ func setupAuthzCacheTestDB(t *testing.T) sqlmock.Sqlmock {
 	}
 
 	database.DB = db
+	restorePersistence := SetPersistence(Persistence{
+		Users:       authdao.NewUserDAO(db),
+		Permissions: authdao.NewPermissionDAO(db),
+		DataScope:   NewDatabaseDataScopeStore(db),
+	})
 	t.Cleanup(func() {
+		restorePersistence()
 		resetDefaultDepartmentTreeCache()
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)

--- a/server/internal/pkg/authz/data_scope_cache_test.go
+++ b/server/internal/pkg/authz/data_scope_cache_test.go
@@ -377,7 +377,6 @@ func setupAuthzCacheTestDB(t *testing.T) sqlmock.Sqlmock {
 
 	resetDefaultDepartmentTreeCache()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -391,7 +390,6 @@ func setupAuthzCacheTestDB(t *testing.T) sqlmock.Sqlmock {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
 
-	database.DB = db
 	restorePersistence := SetPersistence(Persistence{
 		Users:       authdao.NewUserDAO(db),
 		Permissions: authdao.NewPermissionDAO(db),
@@ -404,7 +402,6 @@ func setupAuthzCacheTestDB(t *testing.T) sqlmock.Sqlmock {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
 
 	return mock

--- a/server/internal/pkg/authz/data_scope_store_test.go
+++ b/server/internal/pkg/authz/data_scope_store_test.go
@@ -186,7 +186,9 @@ func withoutAuthzGlobals(t *testing.T) {
 	oldRedis := redisstore.Client
 	database.DB = nil
 	redisstore.Client = nil
+	restorePersistence := SetPersistence(Persistence{})
 	t.Cleanup(func() {
+		restorePersistence()
 		resetDefaultDepartmentTreeCache()
 		database.DB = oldDB
 		redisstore.Client = oldRedis

--- a/server/internal/pkg/authz/data_scope_test.go
+++ b/server/internal/pkg/authz/data_scope_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-admin-kit/server/internal/model"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
@@ -223,7 +222,6 @@ func setupAuthzTestDB(t *testing.T) {
 	t.Helper()
 
 	resetDefaultDepartmentTreeCache()
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -243,13 +241,15 @@ func setupAuthzTestDB(t *testing.T) {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
 
-	database.DB = db
+	restorePersistence := SetPersistence(Persistence{
+		DataScope: NewDatabaseDataScopeStore(db),
+	})
 	t.Cleanup(func() {
+		restorePersistence()
 		resetDefaultDepartmentTreeCache()
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
 }

--- a/server/internal/pkg/authz/permissions.go
+++ b/server/internal/pkg/authz/permissions.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-admin-kit/server/internal/dao/auth"
 )
 
 func UserHasPermissionContext(ctx context.Context, userID uint, requiredPermission string) (bool, error) {
@@ -18,8 +17,12 @@ func UserHasPermissionContext(ctx context.Context, userID uint, requiredPermissi
 		return false, nil
 	}
 
-	userDAO := auth.UserDAO{}
-	user, err := userDAO.GetUserWithRolesContext(ctx, userID)
+	p := currentPersistence()
+	if p.Users == nil || p.Permissions == nil {
+		return false, ErrPersistenceNotConfigured
+	}
+
+	user, err := p.Users.GetUserWithRolesContext(ctx, userID)
 	if err != nil {
 		return false, err
 	}
@@ -29,8 +32,7 @@ func UserHasPermissionContext(ctx context.Context, userID uint, requiredPermissi
 		}
 	}
 
-	permissionDAO := auth.PermissionDAO{}
-	permissions, err := permissionDAO.GetUserPermissionsContext(ctx, userID)
+	permissions, err := p.Permissions.GetUserPermissionsContext(ctx, userID)
 	if err != nil {
 		return false, err
 	}

--- a/server/internal/pkg/authz/persistence.go
+++ b/server/internal/pkg/authz/persistence.go
@@ -1,0 +1,57 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/go-admin-kit/server/internal/model"
+)
+
+// ErrPersistenceNotConfigured reports that package-level authz helpers were
+// used before SetPersistence installed their backing stores.
+var ErrPersistenceNotConfigured = errors.New("authz persistence is not configured")
+
+// UserWithRolesStore loads users with their roles.
+type UserWithRolesStore interface {
+	GetUserWithRolesContext(ctx context.Context, id uint) (*model.User, error)
+}
+
+// UserPermissionsStore loads permission codes for a user.
+type UserPermissionsStore interface {
+	GetUserPermissionsContext(ctx context.Context, userID uint) ([]string, error)
+}
+
+// Persistence groups the stores backing package-level authz helpers.
+type Persistence struct {
+	Users       UserWithRolesStore
+	Permissions UserPermissionsStore
+	DataScope   DataScopeStore
+}
+
+var (
+	persistenceMu sync.RWMutex
+	persistence   Persistence
+)
+
+// SetPersistence installs the stores behind package-level authz helpers and
+// returns a restore function. Helpers read the current persistence per call,
+// so wiring only needs to happen before the first request is served.
+func SetPersistence(p Persistence) func() {
+	persistenceMu.Lock()
+	previous := persistence
+	persistence = p
+	persistenceMu.Unlock()
+
+	return func() {
+		persistenceMu.Lock()
+		persistence = previous
+		persistenceMu.Unlock()
+	}
+}
+
+func currentPersistence() Persistence {
+	persistenceMu.RLock()
+	defer persistenceMu.RUnlock()
+	return persistence
+}

--- a/server/internal/pkg/runtimeconfig/security_policy.go
+++ b/server/internal/pkg/runtimeconfig/security_policy.go
@@ -71,9 +71,36 @@ func DefaultSecurityPolicyReader() *CachedSecurityPolicyReader {
 	return defaultSecurityPolicyReader
 }
 
+var (
+	securityPolicyStoreMu sync.RWMutex
+	securityPolicyStore   SecurityPolicyStore
+)
+
+// SetSecurityPolicyStore installs the store behind DefaultSecurityPolicyReader
+// and returns a restore function. The default reader resolves the store per
+// lookup, so wiring only needs to happen before the first request is served.
+func SetSecurityPolicyStore(store SecurityPolicyStore) func() {
+	securityPolicyStoreMu.Lock()
+	previous := securityPolicyStore
+	securityPolicyStore = store
+	securityPolicyStoreMu.Unlock()
+
+	return func() {
+		securityPolicyStoreMu.Lock()
+		securityPolicyStore = previous
+		securityPolicyStoreMu.Unlock()
+	}
+}
+
 type defaultSecurityPolicyStore struct{}
 
 func (defaultSecurityPolicyStore) GetByKeyContext(ctx context.Context, key string) (*model.SystemSetting, error) {
+	securityPolicyStoreMu.RLock()
+	store := securityPolicyStore
+	securityPolicyStoreMu.RUnlock()
+	if store != nil {
+		return store.GetByKeyContext(ctx, key)
+	}
 	if database.DB == nil {
 		return nil, ErrStoreUnavailable
 	}

--- a/server/internal/service/auth/console_permissions_test.go
+++ b/server/internal/service/auth/console_permissions_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/go-admin-kit/server/internal/model"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 )
 
 func TestConsoleRoleCodesTrimsDeduplicatesAndSorts(t *testing.T) {
@@ -23,16 +22,12 @@ func TestConsoleRoleCodesTrimsDeduplicatesAndSorts(t *testing.T) {
 }
 
 func TestConsolePermissionsForUserAddsAliasesAndSuperAdminDefaults(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	user := &model.User{
 		Roles: []model.Role{{Code: "super_admin"}},
 	}
-	got := ConsolePermissionsForUser(context.Background(), user, []string{
+	// A zero-value route service falls back to the static route seed, so the
+	// test needs no database.
+	got := ConsolePermissionsForUser(context.Background(), ConsoleRouteService{}, user, []string{
 		"system:user:list",
 		"system:role:update",
 	})

--- a/server/internal/service/auth/console_routes.go
+++ b/server/internal/service/auth/console_routes.go
@@ -24,7 +24,16 @@ func (e ConsoleRouteValidationError) Error() string {
 	return e.Message
 }
 
-type ConsoleRouteService struct{}
+type ConsoleRouteService struct {
+	dao *authDAO.ConsoleRouteDAO
+}
+
+// NewConsoleRouteServiceWithDB builds a ConsoleRouteService backed by an
+// injected database handle.
+func NewConsoleRouteServiceWithDB(db *gorm.DB) ConsoleRouteService {
+	dao := authDAO.NewConsoleRouteDAO(db)
+	return ConsoleRouteService{dao: &dao}
+}
 
 type ConsoleRouteView struct {
 	RouteKey     string         `json:"route_key"`
@@ -79,6 +88,9 @@ type ConsoleRouteBootstrapResult struct {
 }
 
 func (s ConsoleRouteService) routeDAO() authDAO.ConsoleRouteDAO {
+	if s.dao != nil {
+		return *s.dao
+	}
 	return authDAO.NewConsoleRouteDAO()
 }
 

--- a/server/internal/service/auth/console_routes.go
+++ b/server/internal/service/auth/console_routes.go
@@ -534,14 +534,14 @@ func ConsoleRoleCodes(roles []model.Role) []string {
 	return UniqueSortedConsoleStrings(values)
 }
 
-func ConsolePermissionsForUser(ctx context.Context, user *model.User, base []string) []string {
+func ConsolePermissionsForUser(ctx context.Context, routes ConsoleRouteService, user *model.User, base []string) []string {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	values := append([]string{}, base...)
 	values = append(values, consolePermissionAliases(base)...)
 	if ConsoleHasRole(user, "super_admin") {
-		routePermissions, err := ConsoleRouteService{}.AllRoutePermissionsContext(ctx)
+		routePermissions, err := routes.AllRoutePermissionsContext(ctx)
 		if err != nil {
 			routePermissions = AllConsoleRoutePermissions()
 		}

--- a/server/internal/service/auth/console_routes_context_test.go
+++ b/server/internal/service/auth/console_routes_context_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestConsoleRouteServiceListRoutesContextHonorsCanceledContext(t *testing.T) {
-	setupAuthServiceContextTestDB(t)
+	db, _ := setupAuthServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (ConsoleRouteService{}).ListRoutesContext(ctx)
+	svc := NewConsoleRouteServiceWithDB(db)
+	_, err := svc.ListRoutesContext(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListRoutesContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/service/auth/console_session.go
+++ b/server/internal/service/auth/console_session.go
@@ -22,7 +22,16 @@ var (
 )
 
 // ConsoleSessionService persists and validates web-console cookie sessions.
-type ConsoleSessionService struct{}
+type ConsoleSessionService struct {
+	dao *authDAO.ConsoleSessionDAO
+}
+
+// NewConsoleSessionServiceWithDB builds a ConsoleSessionService backed by an
+// injected database handle.
+func NewConsoleSessionServiceWithDB(db *gorm.DB) ConsoleSessionService {
+	dao := authDAO.NewConsoleSessionDAO(db)
+	return ConsoleSessionService{dao: &dao}
+}
 
 type ConsoleSessionUser struct {
 	ID                 uint     `json:"id"`
@@ -49,6 +58,9 @@ type ConsoleSessionResponse struct {
 }
 
 func (s ConsoleSessionService) sessionDAO() authDAO.ConsoleSessionDAO {
+	if s.dao != nil {
+		return *s.dao
+	}
 	return authDAO.ConsoleSessionDAO{}
 }
 

--- a/server/internal/service/auth/console_session_test.go
+++ b/server/internal/service/auth/console_session_test.go
@@ -33,12 +33,13 @@ func TestTruncateRunesPreservesRuneBoundaries(t *testing.T) {
 }
 
 func TestConsoleSessionServiceValidateActiveSessionContextHonorsCanceledContext(t *testing.T) {
-	setupAuthServiceContextTestDB(t)
+	db, _ := setupAuthServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (ConsoleSessionService{}).ValidateActiveSessionContext(ctx, "session-1", "alice")
+	svc := NewConsoleSessionServiceWithDB(db)
+	_, err := svc.ValidateActiveSessionContext(ctx, "session-1", "alice")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ValidateActiveSessionContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/service/auth/oauth.go
+++ b/server/internal/service/auth/oauth.go
@@ -40,6 +40,16 @@ type OAuthService struct {
 	policyReader    runtimeconfig.SecurityPolicyReader
 }
 
+// NewOAuthServiceWithDB builds an OAuthService whose binding and user stores
+// use an injected database handle. State store and provider clients keep
+// their default implementations.
+func NewOAuthServiceWithDB(db *gorm.DB) *OAuthService {
+	return &OAuthService{
+		bindingDAO: authDAO.NewOAuthBindingDAO(db),
+		userDAO:    authDAO.NewUserDAO(db),
+	}
+}
+
 type oauthProviderClient interface {
 	AuthURLContext(ctx context.Context) (string, error)
 	ResolveIdentityContext(ctx context.Context, code, state string) (*oauthIdentity, error)

--- a/server/internal/service/auth/oauth_context_test.go
+++ b/server/internal/service/auth/oauth_context_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-admin-kit/server/internal/config"
 	"github.com/go-admin-kit/server/internal/model"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"github.com/go-admin-kit/server/internal/pkg/jwt"
 	"github.com/go-admin-kit/server/internal/pkg/runtimeconfig"
 	"github.com/go-sql-driver/mysql"
@@ -17,24 +16,18 @@ import (
 )
 
 func TestOAuthServiceFindOrCreateUserContextHonorsCanceledContext(t *testing.T) {
-	setupAuthServiceContextTestDB(t)
+	db, _ := setupAuthServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&OAuthService{}).findOrCreateUserContext(ctx, "github", "123", "alice", "alice@example.com", "")
+	_, err := NewOAuthServiceWithDB(db).findOrCreateUserContext(ctx, "github", "123", "alice", "alice@example.com", "")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("findOrCreateUserContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestOAuthServiceFindOrCreateUserContextUsesInjectedStoresForExistingBinding(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	bindings := &stubOAuthBindingStore{
 		binding: &model.OAuthBinding{UserID: 42},
 	}
@@ -66,11 +59,6 @@ func TestOAuthServiceFindOrCreateUserContextUsesInjectedStoresForExistingBinding
 
 func TestOAuthServiceGithubCallbackContextRequiresTOTPForEnabledUser(t *testing.T) {
 	setOAuthJWTTestConfig(t)
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
 
 	svc := &OAuthService{
 		bindingDAO: &stubOAuthBindingStore{binding: &model.OAuthBinding{UserID: 42}},
@@ -102,12 +90,6 @@ func TestOAuthServiceGithubCallbackContextRequiresTOTPForEnabledUser(t *testing.
 }
 
 func TestOAuthServiceGithubCallbackContextRejectsDisabledUser(t *testing.T) {
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
-
 	svc := &OAuthService{
 		bindingDAO: &stubOAuthBindingStore{binding: &model.OAuthBinding{UserID: 42}},
 		userDAO: &stubOAuthUserStore{
@@ -131,11 +113,6 @@ func TestOAuthServiceGithubCallbackContextMarksDefaultAdminPassword(t *testing.T
 	config.Cfg.Security.DefaultAdmin.DefaultUsername = "admin"
 	t.Cleanup(func() {
 		config.Cfg.Security = oldSecurity
-	})
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
 	})
 
 	users := &stubOAuthUserStore{
@@ -168,11 +145,6 @@ func TestOAuthServiceGithubCallbackContextMarksDefaultAdminPassword(t *testing.T
 
 func TestOAuthServiceGithubCallbackContextUsesRuntimePasswordMaxAge(t *testing.T) {
 	setOAuthJWTTestConfig(t)
-	oldDB := database.DB
-	database.DB = nil
-	t.Cleanup(func() {
-		database.DB = oldDB
-	})
 
 	changedAt := time.Now().AddDate(0, 0, -60)
 	users := &stubOAuthUserStore{
@@ -298,21 +270,24 @@ func TestOAuthServiceBindOAuthContextRequiresAuthorizationCode(t *testing.T) {
 }
 
 func TestOAuthServiceGithubCallbackContextFailsClosedWithoutProviderClient(t *testing.T) {
-	_, err := (&OAuthService{}).GithubCallbackContext(context.Background(), "oauth-code", "state")
+	db, _ := setupAuthServiceContextTestDB(t)
+	_, err := NewOAuthServiceWithDB(db).GithubCallbackContext(context.Background(), "oauth-code", "state")
 	if !errors.Is(err, ErrOAuthProviderUnavailable) {
 		t.Fatalf("GithubCallbackContext() error = %v, want ErrOAuthProviderUnavailable", err)
 	}
 }
 
 func TestOAuthServiceGetGithubAuthURLFailsClosedWithoutProviderClient(t *testing.T) {
-	_, err := (&OAuthService{}).GetGithubAuthURLContext(context.Background())
+	db, _ := setupAuthServiceContextTestDB(t)
+	_, err := NewOAuthServiceWithDB(db).GetGithubAuthURLContext(context.Background())
 	if !errors.Is(err, ErrOAuthProviderUnavailable) {
 		t.Fatalf("GetGithubAuthURL() error = %v, want ErrOAuthProviderUnavailable", err)
 	}
 }
 
 func TestOAuthServiceBindOAuthContextFailsClosedWithoutProviderClient(t *testing.T) {
-	err := (&OAuthService{}).BindOAuthContext(context.Background(), 42, BindOAuthRequest{
+	db, _ := setupAuthServiceContextTestDB(t)
+	err := NewOAuthServiceWithDB(db).BindOAuthContext(context.Background(), 42, BindOAuthRequest{
 		Provider: "github",
 		Code:     "oauth-code",
 	})

--- a/server/internal/service/auth/totp_test.go
+++ b/server/internal/service/auth/totp_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestLoginPasswordContextReturnsTOTPChallengeWhenEnabled(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.JWT.Secret = "local-dev-secret-for-totp-tests-32"
 	config.Cfg.JWT.Issuer = "go-admin-kit-test"
@@ -28,7 +29,7 @@ func TestLoginPasswordContextReturnsTOTPChallengeWhenEnabled(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "status", "must_change_password", "totp_enabled"}).
 			AddRow(uint(7), "alice", currentHash, int8(1), false, true))
 
-	resp, err := (&UserService{}).LoginPasswordContext(context.Background(), "alice", "CurrentPass1")
+	resp, err := (&svc).LoginPasswordContext(context.Background(), "alice", "CurrentPass1")
 	if err != nil {
 		t.Fatalf("LoginPasswordContext() error = %v", err)
 	}
@@ -48,7 +49,8 @@ func TestLoginPasswordContextReturnsTOTPChallengeWhenEnabled(t *testing.T) {
 }
 
 func TestVerifyTOTPLoginContextIssuesTokensForValidCode(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	restoreStore := jwt.SetTokenBlacklistStore(newTOTPTestBlacklistStore())
 	t.Cleanup(restoreStore)
 	oldCfg := config.Cfg
@@ -75,7 +77,7 @@ func TestVerifyTOTPLoginContextIssuesTokensForValidCode(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "status", "totp_enabled", "totp_secret"}).
 			AddRow(uint(7), "alice", int8(1), true, secret))
 
-	resp, err := (&UserService{}).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
+	resp, err := (&svc).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
 		ChallengeID: challenge,
 		Code:        code,
 	})
@@ -92,7 +94,8 @@ func TestVerifyTOTPLoginContextIssuesTokensForValidCode(t *testing.T) {
 }
 
 func TestVerifyTOTPLoginContextAcceptsRecoveryCodeOnce(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	restoreStore := jwt.SetTokenBlacklistStore(newTOTPTestBlacklistStore())
 	t.Cleanup(restoreStore)
 	oldCfg := config.Cfg
@@ -125,7 +128,7 @@ func TestVerifyTOTPLoginContextAcceptsRecoveryCodeOnce(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	resp, err := (&UserService{}).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
+	resp, err := (&svc).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
 		ChallengeID: challenge,
 		Code:        recoveryCode,
 	})
@@ -138,7 +141,8 @@ func TestVerifyTOTPLoginContextAcceptsRecoveryCodeOnce(t *testing.T) {
 }
 
 func TestVerifyTOTPLoginContextRejectsInvalidRecoveryCodeWithoutMarkingUsed(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.JWT.Secret = "local-dev-secret-for-totp-tests-32"
 	config.Cfg.JWT.Issuer = "go-admin-kit-test"
@@ -161,7 +165,7 @@ func TestVerifyTOTPLoginContextRejectsInvalidRecoveryCodeWithoutMarkingUsed(t *t
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "code_hash", "used_at"}).
 			AddRow(uint(11), uint(7), codeHash, nil))
 
-	_, err = (&UserService{}).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
+	_, err = (&svc).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
 		ChallengeID: challenge,
 		Code:        "ZZZZZ-ZZZZZ-ZZZZZ",
 	})
@@ -171,7 +175,8 @@ func TestVerifyTOTPLoginContextRejectsInvalidRecoveryCodeWithoutMarkingUsed(t *t
 }
 
 func TestVerifyTOTPLoginContextRejectsInvalidTOTPWithoutRecoveryLookup(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.JWT.Secret = "local-dev-secret-for-totp-tests-32"
 	config.Cfg.JWT.Issuer = "go-admin-kit-test"
@@ -189,7 +194,7 @@ func TestVerifyTOTPLoginContextRejectsInvalidTOTPWithoutRecoveryLookup(t *testin
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "status", "totp_enabled", "totp_secret"}).
 			AddRow(uint(7), "alice", int8(1), true, "JBSWY3DPEHPK3PXP"))
 
-	_, err = (&UserService{}).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
+	_, err = (&svc).VerifyTOTPLoginContext(context.Background(), VerifyTOTPLoginRequest{
 		ChallengeID: challenge,
 		Code:        "000000",
 	})
@@ -199,7 +204,8 @@ func TestVerifyTOTPLoginContextRejectsInvalidTOTPWithoutRecoveryLookup(t *testin
 }
 
 func TestGenerateTOTPSetupContextStoresSecretDisabled(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.App.Name = "go-admin-kit"
 	t.Cleanup(func() {
@@ -216,7 +222,7 @@ func TestGenerateTOTPSetupContextStoresSecretDisabled(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	setup, err := (&UserService{}).GenerateTOTPSetupContext(context.Background(), 7, TOTPSetupRequest{
+	setup, err := (&svc).GenerateTOTPSetupContext(context.Background(), 7, TOTPSetupRequest{
 		CurrentPassword: "CurrentPass1",
 	})
 	if err != nil {
@@ -228,7 +234,8 @@ func TestGenerateTOTPSetupContextStoresSecretDisabled(t *testing.T) {
 }
 
 func TestEnableTOTPContextReturnsRecoveryCodes(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 
 	secret := "JBSWY3DPEHPK3PXP"
 	code, err := totp.GenerateCode(secret, time.Now())
@@ -251,7 +258,7 @@ func TestEnableTOTPContextReturnsRecoveryCodes(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 8))
 	mock.ExpectCommit()
 
-	resp, err := (&UserService{}).EnableTOTPContext(context.Background(), 7, TOTPVerifyRequest{
+	resp, err := (&svc).EnableTOTPContext(context.Background(), 7, TOTPVerifyRequest{
 		Code:            code,
 		CurrentPassword: "CurrentPass1",
 	})
@@ -269,7 +276,8 @@ func TestEnableTOTPContextReturnsRecoveryCodes(t *testing.T) {
 }
 
 func TestEnableTOTPContextRejectsMissingCurrentPassword(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 
 	secret := "JBSWY3DPEHPK3PXP"
 	code, err := totp.GenerateCode(secret, time.Now())
@@ -282,14 +290,15 @@ func TestEnableTOTPContextRejectsMissingCurrentPassword(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "status", "totp_enabled", "totp_secret"}).
 			AddRow(uint(7), "alice", mustHashPasswordForTest(t, "CurrentPass1"), int8(1), false, secret))
 
-	_, err = (&UserService{}).EnableTOTPContext(context.Background(), 7, TOTPVerifyRequest{Code: code})
+	_, err = (&svc).EnableTOTPContext(context.Background(), 7, TOTPVerifyRequest{Code: code})
 	if !errors.Is(err, ErrOldPasswordIncorrect) {
 		t.Fatalf("EnableTOTPContext() error = %v, want ErrOldPasswordIncorrect", err)
 	}
 }
 
 func TestRegenerateTOTPRecoveryCodesContextReturnsNewCodes(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 
 	secret := "JBSWY3DPEHPK3PXP"
 	code, err := totp.GenerateCode(secret, time.Now())
@@ -309,7 +318,7 @@ func TestRegenerateTOTPRecoveryCodesContextReturnsNewCodes(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 8))
 	mock.ExpectCommit()
 
-	resp, err := (&UserService{}).RegenerateTOTPRecoveryCodesContext(context.Background(), 7, TOTPVerifyRequest{
+	resp, err := (&svc).RegenerateTOTPRecoveryCodesContext(context.Background(), 7, TOTPVerifyRequest{
 		Code:            code,
 		CurrentPassword: "CurrentPass1",
 	})

--- a/server/internal/service/auth/user.go
+++ b/server/internal/service/auth/user.go
@@ -23,6 +23,11 @@ type UserService struct {
 	policyReader runtimeconfig.SecurityPolicyReader
 }
 
+// NewUserServiceWithDB builds a UserService backed by an injected database handle.
+func NewUserServiceWithDB(db *gorm.DB) UserService {
+	return UserService{userDAO: *auth.NewUserDAO(db)}
+}
+
 // LoginRequest is the login request payload.
 type LoginRequest struct {
 	Username    string `json:"username" binding:"required"`

--- a/server/internal/service/auth/user_context_test.go
+++ b/server/internal/service/auth/user_context_test.go
@@ -7,30 +7,31 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestUserServiceLoginPasswordContextHonorsCanceledContext(t *testing.T) {
-	setupAuthServiceContextTestDB(t)
+	db, _ := setupAuthServiceContextTestDB(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&UserService{}).LoginPasswordContext(ctx, "alice", "Password123")
+	svc := NewUserServiceWithDB(db)
+	_, err := svc.LoginPasswordContext(ctx, "alice", "Password123")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("LoginPasswordContext() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestUserServiceRegisterContextReturnsUsernameLookupError(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE username = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs("alice", 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&UserService{}).RegisterContext(context.Background(), RegisterRequest{
+	svc := NewUserServiceWithDB(db)
+	_, err := svc.RegisterContext(context.Background(), RegisterRequest{
 		Username: "alice",
 		Password: "Password123",
 		Email:    "alice@example.com",
@@ -40,10 +41,9 @@ func TestUserServiceRegisterContextReturnsUsernameLookupError(t *testing.T) {
 	}
 }
 
-func setupAuthServiceContextTestDB(t *testing.T) sqlmock.Sqlmock {
+func setupAuthServiceContextTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -56,14 +56,12 @@ func setupAuthServiceContextTestDB(t *testing.T) sqlmock.Sqlmock {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
 
-	database.DB = db
 	t.Cleanup(func() {
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
 
-	return mock
+	return db, mock
 }

--- a/server/internal/service/auth/user_password_history_test.go
+++ b/server/internal/service/auth/user_password_history_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestChangePasswordContextRejectsRecentlyUsedPassword(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.Security.PasswordHistoryCount = 5
 	t.Cleanup(func() {
@@ -35,7 +36,7 @@ func TestChangePasswordContextRejectsRecentlyUsedPassword(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "password_hash", "changed_at"}).
 			AddRow(uint(1), uint(7), reusedHash, changedAt))
 
-	err := (&UserService{}).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
+	err := (&svc).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
 		OldPassword: "CurrentPass1",
 		NewPassword: "UsedPass1",
 	})
@@ -45,7 +46,8 @@ func TestChangePasswordContextRejectsRecentlyUsedPassword(t *testing.T) {
 }
 
 func TestChangePasswordContextUpdatesPasswordAndHistoryAtomically(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.Security.PasswordHistoryCount = 5
 	t.Cleanup(func() {
@@ -70,7 +72,7 @@ func TestChangePasswordContextUpdatesPasswordAndHistoryAtomically(t *testing.T) 
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	err := (&UserService{}).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
+	err := (&svc).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
 		OldPassword: "CurrentPass1",
 		NewPassword: "FreshPass1",
 	})
@@ -80,7 +82,8 @@ func TestChangePasswordContextUpdatesPasswordAndHistoryAtomically(t *testing.T) 
 }
 
 func TestChangePasswordContextUsesRuntimePasswordHistoryCount(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.Security.PasswordHistoryCount = 5
 	t.Cleanup(func() {
@@ -105,8 +108,8 @@ func TestChangePasswordContextUsesRuntimePasswordHistoryCount(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	service := &UserService{policyReader: stubSecurityPolicyReader{policy: runtimeconfig.SecurityPolicy{PasswordHistoryCount: 2}}}
-	err := service.ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
+	svc.policyReader = stubSecurityPolicyReader{policy: runtimeconfig.SecurityPolicy{PasswordHistoryCount: 2}}
+	err := (&svc).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
 		OldPassword: "CurrentPass1",
 		NewPassword: "FreshPass1",
 	})
@@ -116,7 +119,8 @@ func TestChangePasswordContextUsesRuntimePasswordHistoryCount(t *testing.T) {
 }
 
 func TestChangePasswordContextReturnsOldPasswordErrorWhenConcurrentUpdateWins(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.Security.PasswordHistoryCount = 0
 	t.Cleanup(func() {
@@ -135,7 +139,7 @@ func TestChangePasswordContextReturnsOldPasswordErrorWhenConcurrentUpdateWins(t 
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectRollback()
 
-	err := (&UserService{}).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
+	err := (&svc).ChangePasswordContext(context.Background(), 7, ChangePasswordRequest{
 		OldPassword: "CurrentPass1",
 		NewPassword: "FreshPass1",
 	})
@@ -145,7 +149,8 @@ func TestChangePasswordContextReturnsOldPasswordErrorWhenConcurrentUpdateWins(t 
 }
 
 func TestUserServiceLoginPasswordContextReturnsUpdateErrorWhenExpiredFlagCannotPersist(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.Security.PasswordMaxAgeDays = 30
 	t.Cleanup(func() {
@@ -166,14 +171,15 @@ func TestUserServiceLoginPasswordContextReturnsUpdateErrorWhenExpiredFlagCannotP
 		WillReturnError(updateErr)
 	mock.ExpectRollback()
 
-	_, err := (&UserService{}).LoginPasswordContext(context.Background(), "alice", "CurrentPass1")
+	_, err := (&svc).LoginPasswordContext(context.Background(), "alice", "CurrentPass1")
 	if !errors.Is(err, updateErr) {
 		t.Fatalf("LoginPasswordContext() error = %v, want update error", err)
 	}
 }
 
 func TestUserServiceLoginPasswordContextUsesRuntimePasswordMaxAge(t *testing.T) {
-	mock := setupAuthServiceContextTestDB(t)
+	db, mock := setupAuthServiceContextTestDB(t)
+	svc := NewUserServiceWithDB(db)
 	oldCfg := config.Cfg
 	config.Cfg.Security.PasswordMaxAgeDays = 0
 	t.Cleanup(func() {
@@ -200,8 +206,8 @@ func TestUserServiceLoginPasswordContextUsesRuntimePasswordMaxAge(t *testing.T) 
 		WithArgs(uint(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "role_id"}))
 
-	service := &UserService{policyReader: stubSecurityPolicyReader{policy: runtimeconfig.SecurityPolicy{PasswordMaxAgeDays: 30}}}
-	resp, err := service.LoginPasswordContext(context.Background(), "alice", "CurrentPass1")
+	svc.policyReader = stubSecurityPolicyReader{policy: runtimeconfig.SecurityPolicy{PasswordMaxAgeDays: 30}}
+	resp, err := (&svc).LoginPasswordContext(context.Background(), "alice", "CurrentPass1")
 	if err != nil {
 		t.Fatalf("LoginPasswordContext() error = %v", err)
 	}

--- a/server/internal/service/monitor/job.go
+++ b/server/internal/service/monitor/job.go
@@ -92,6 +92,17 @@ func GetJobService() *JobService {
 	return jobService
 }
 
+// InitJobService initializes the singleton job service with an injected
+// database handle. It must run before the first GetJobService call to take
+// effect; later calls return the already-initialized singleton.
+func InitJobService(db *gorm.DB) *JobService {
+	once.Do(func() {
+		jobDAO := monitor.NewJobDAO(db)
+		jobService = newJobService(jobDAO, jobDAO.Ready())
+	})
+	return jobService
+}
+
 func newJobService(dao jobDAO, bootstrapJobs bool) *JobService {
 	service := &JobService{
 		dao:  dao,

--- a/server/internal/service/monitor/mysql.go
+++ b/server/internal/service/monitor/mysql.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-admin-kit/server/internal/config"
 	monitordao "github.com/go-admin-kit/server/internal/dao/monitor"
+	"gorm.io/gorm"
 )
 
 type mySQLDAO interface {
@@ -24,6 +25,11 @@ type MySQLService struct {
 
 func NewMySQLService() *MySQLService {
 	return &MySQLService{dao: monitordao.NewMySQLDAO()}
+}
+
+// NewMySQLServiceWithDB builds a MySQLService backed by an injected database handle.
+func NewMySQLServiceWithDB(db *gorm.DB) *MySQLService {
+	return &MySQLService{dao: monitordao.NewMySQLDAO(db)}
 }
 
 func (s *MySQLService) GetMySQLInfoContext(ctx context.Context) (map[string]any, error) {

--- a/server/internal/service/system/audit_log.go
+++ b/server/internal/service/system/audit_log.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	dao "github.com/go-admin-kit/server/internal/dao/system"
 	"github.com/go-admin-kit/server/internal/model"
+	"gorm.io/gorm"
 )
 
 const (
@@ -20,6 +21,12 @@ const (
 // AuditLogService handles independent business audit log behavior.
 type AuditLogService struct {
 	logDAO dao.AuditLogDAO
+}
+
+// NewAuditLogServiceWithDB builds an AuditLogService backed by an injected
+// database handle.
+func NewAuditLogServiceWithDB(db *gorm.DB) AuditLogService {
+	return AuditLogService{logDAO: *dao.NewAuditLogDAO(db)}
 }
 
 type AuditLogListRequest struct {

--- a/server/internal/service/system/audit_log_context_test.go
+++ b/server/internal/service/system/audit_log_context_test.go
@@ -7,12 +7,13 @@ import (
 )
 
 func TestAuditLogServiceListLogsContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&AuditLogService{}).ListLogsContext(ctx, AuditLogListRequest{Page: 1, PageSize: 10})
+	svc := NewAuditLogServiceWithDB(db)
+	_, err := (&svc).ListLogsContext(ctx, AuditLogListRequest{Page: 1, PageSize: 10})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListLogsContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/service/system/cache.go
+++ b/server/internal/service/system/cache.go
@@ -7,18 +7,27 @@ import (
 	"github.com/go-admin-kit/server/internal/pkg/cache"
 )
 
+// PermissionCacheStore resolves the users affected by role or permission changes.
+type PermissionCacheStore interface {
+	FindUserIDsByRoleIDsContext(ctx context.Context, roleIDs []uint) ([]uint, error)
+	FindRoleIDsByPermissionIDsContext(ctx context.Context, permissionIDs []uint) ([]uint, error)
+}
+
 func InvalidatePermissionCacheForUsersContext(ctx context.Context, userIDs ...uint) error {
 	uniqueUserIDs := uniqueUint(userIDs)
 	return cache.NewCacheService().DelUserPermissionsBatchContext(ctx, uniqueUserIDs)
 }
 
-func InvalidatePermissionCacheByRolesContext(ctx context.Context, roleIDs ...uint) error {
+func InvalidatePermissionCacheByRolesContext(ctx context.Context, store PermissionCacheStore, roleIDs ...uint) error {
 	roleIDs = uniqueUint(roleIDs)
 	if len(roleIDs) == 0 {
 		return nil
 	}
 
-	userIDs, err := (&systemdao.PermissionCacheDAO{}).FindUserIDsByRoleIDsContext(ctx, roleIDs)
+	if store == nil {
+		store = &systemdao.PermissionCacheDAO{}
+	}
+	userIDs, err := store.FindUserIDsByRoleIDsContext(ctx, roleIDs)
 	if err != nil {
 		return err
 	}
@@ -26,18 +35,21 @@ func InvalidatePermissionCacheByRolesContext(ctx context.Context, roleIDs ...uin
 	return InvalidatePermissionCacheForUsersContext(ctx, userIDs...)
 }
 
-func InvalidatePermissionCacheByPermissionsContext(ctx context.Context, permissionIDs ...uint) error {
+func InvalidatePermissionCacheByPermissionsContext(ctx context.Context, store PermissionCacheStore, permissionIDs ...uint) error {
 	permissionIDs = uniqueUint(permissionIDs)
 	if len(permissionIDs) == 0 {
 		return nil
 	}
 
-	roleIDs, err := (&systemdao.PermissionCacheDAO{}).FindRoleIDsByPermissionIDsContext(ctx, permissionIDs)
+	if store == nil {
+		store = &systemdao.PermissionCacheDAO{}
+	}
+	roleIDs, err := store.FindRoleIDsByPermissionIDsContext(ctx, permissionIDs)
 	if err != nil {
 		return err
 	}
 
-	return InvalidatePermissionCacheByRolesContext(ctx, roleIDs...)
+	return InvalidatePermissionCacheByRolesContext(ctx, store, roleIDs...)
 }
 
 func InvalidatePermissionCacheAllContext(ctx context.Context) error {

--- a/server/internal/service/system/cache_context_test.go
+++ b/server/internal/service/system/cache_context_test.go
@@ -12,7 +12,7 @@ func TestInvalidatePermissionCacheByRolesContextHonorsCanceledContext(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := InvalidatePermissionCacheByRolesContext(ctx, 1)
+	err := InvalidatePermissionCacheByRolesContext(ctx, nil, 1)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("InvalidatePermissionCacheByRolesContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/service/system/cache_context_test.go
+++ b/server/internal/service/system/cache_context_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	systemdao "github.com/go-admin-kit/server/internal/dao/system"
 )
 
 func TestInvalidatePermissionCacheByRolesContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := InvalidatePermissionCacheByRolesContext(ctx, nil, 1)
+	err := InvalidatePermissionCacheByRolesContext(ctx, systemdao.NewPermissionCacheDAO(db), 1)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("InvalidatePermissionCacheByRolesContext() error = %v, want context.Canceled", err)
 	}

--- a/server/internal/service/system/department.go
+++ b/server/internal/service/system/department.go
@@ -29,6 +29,12 @@ type DepartmentService struct {
 	deptDAO departmentDAO
 }
 
+// NewDepartmentServiceWithDB builds a DepartmentService backed by an injected
+// database handle.
+func NewDepartmentServiceWithDB(db *gorm.DB) DepartmentService {
+	return DepartmentService{deptDAO: systemdao.NewDepartmentDAO(db)}
+}
+
 const departmentTreeInvalidationTimeout = 2 * time.Second
 
 func warnDepartmentTreeInvalidation(err error) {

--- a/server/internal/service/system/department_test.go
+++ b/server/internal/service/system/department_test.go
@@ -35,12 +35,13 @@ func TestDepartmentServiceCreateInvalidatesDepartmentTreeCache(t *testing.T) {
 }
 
 func TestDepartmentServiceCreateContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&DepartmentService{}).CreateContext(ctx, CreateDepartmentRequest{
+	svc := NewDepartmentServiceWithDB(db)
+	_, err := (&svc).CreateContext(ctx, CreateDepartmentRequest{
 		Name: "Engineering",
 		Code: "eng",
 	})

--- a/server/internal/service/system/dict.go
+++ b/server/internal/service/system/dict.go
@@ -14,6 +14,11 @@ type DictService struct {
 	dictDAO systemdao.DictDAO
 }
 
+// NewDictServiceWithDB builds a DictService backed by an injected database handle.
+func NewDictServiceWithDB(db *gorm.DB) DictService {
+	return DictService{dictDAO: *systemdao.NewDictDAO(db)}
+}
+
 type DictTypeListRequest struct {
 	pagination.PageRequest
 	Keyword string `form:"keyword" json:"keyword"`

--- a/server/internal/service/system/dict_context_test.go
+++ b/server/internal/service/system/dict_context_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestDictServiceCreateTypeContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&DictService{}).CreateTypeContext(ctx, CreateDictTypeRequest{
+	svc := NewDictServiceWithDB(db)
+	_, err := (&svc).CreateTypeContext(ctx, CreateDictTypeRequest{
 		Name: "Gender",
 		Code: "gender",
 	})
@@ -23,13 +24,14 @@ func TestDictServiceCreateTypeContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestDictServiceCreateTypeContextReturnsCodeLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `dict_types` WHERE code = ? ORDER BY `dict_types`.`id` LIMIT ?")).
 		WithArgs("gender", 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&DictService{}).CreateTypeContext(context.Background(), CreateDictTypeRequest{
+	svc := NewDictServiceWithDB(db)
+	_, err := (&svc).CreateTypeContext(context.Background(), CreateDictTypeRequest{
 		Name: "Gender",
 		Code: "gender",
 	})
@@ -39,13 +41,14 @@ func TestDictServiceCreateTypeContextReturnsCodeLookupError(t *testing.T) {
 }
 
 func TestDictServiceGetMultipleDictDataContextReturnsLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `dict_types` WHERE code = ? ORDER BY `dict_types`.`id` LIMIT ?")).
 		WithArgs("gender", 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&DictService{}).GetMultipleDictDataContext(context.Background(), []string{"gender"})
+	svc := NewDictServiceWithDB(db)
+	_, err := (&svc).GetMultipleDictDataContext(context.Background(), []string{"gender"})
 	if !errors.Is(err, lookupErr) {
 		t.Fatalf("GetMultipleDictDataContext() error = %v, want lookup error", err)
 	}

--- a/server/internal/service/system/file.go
+++ b/server/internal/service/system/file.go
@@ -37,6 +37,15 @@ func NewFileService() *FileService {
 	}
 }
 
+// NewFileServiceWithDB builds a FileService backed by an injected database
+// handle. The uploader keeps its default implementation.
+func NewFileServiceWithDB(db *gorm.DB) *FileService {
+	return &FileService{
+		fileDAO:  *systemdao.NewFileDAO(db),
+		uploader: upload.NewUploader(),
+	}
+}
+
 type FileListRequest struct {
 	pagination.PageRequest
 	UserID    *uint               `form:"user_id" json:"user_id"`

--- a/server/internal/service/system/file_context_test.go
+++ b/server/internal/service/system/file_context_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-admin-kit/server/internal/config"
+	systemdao "github.com/go-admin-kit/server/internal/dao/system"
 	"github.com/go-admin-kit/server/internal/model"
 	"github.com/go-admin-kit/server/internal/pkg/authz"
 	"github.com/go-admin-kit/server/internal/pkg/pagination"
@@ -28,7 +29,7 @@ import (
 )
 
 func TestFileServiceUploadContextPersistsImageDimensions(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	content := systemFixtureBase64(t, "iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAYAAAC56t6BAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAiSURBVBhXY9CImvbfJmrafwaNvGn/bfJAjKZp/22apv0HAKfrDT/onk38AAAAAElFTkSuQmCC")
 	hash := systemMD5Hex(content)
 
@@ -41,7 +42,7 @@ func TestFileServiceUploadContextPersistsImageDimensions(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(7, 1))
 	mock.ExpectCommit()
 
-	service := newLocalUploadFileService(t, ".png")
+	service := newLocalUploadFileService(t, db, ".png")
 	file, err := service.UploadContext(context.Background(), systemMultipartFileHeader(t, "avatar.png", content), 42)
 	if err != nil {
 		t.Fatalf("UploadContext() error = %v", err)
@@ -55,7 +56,7 @@ func TestFileServiceUploadContextPersistsImageDimensions(t *testing.T) {
 }
 
 func TestFileServiceUploadContextReusesExistingImageDimensionsForDuplicateHash(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	content := systemFixtureBase64(t, "iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAYAAAC56t6BAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAiSURBVBhXY9CImvbfJmrafwaNvGn/bfJAjKZp/22apv0HAKfrDT/onk38AAAAAElFTkSuQmCC")
 	hash := systemMD5Hex(content)
 
@@ -71,7 +72,7 @@ func TestFileServiceUploadContextReusesExistingImageDimensionsForDuplicateHash(t
 		WillReturnResult(sqlmock.NewResult(8, 1))
 	mock.ExpectCommit()
 
-	service := newLocalUploadFileService(t, ".png")
+	service := newLocalUploadFileService(t, db, ".png")
 	file, err := service.UploadContext(context.Background(), systemMultipartFileHeader(t, "avatar.png", content), 42)
 	if err != nil {
 		t.Fatalf("UploadContext() error = %v", err)
@@ -85,7 +86,7 @@ func TestFileServiceUploadContextReusesExistingImageDimensionsForDuplicateHash(t
 }
 
 func TestFileServiceUploadContextPersistsThumbnailFields(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	content := systemPNG(t, 400, 200)
 	hash := systemMD5Hex(content)
 
@@ -98,7 +99,7 @@ func TestFileServiceUploadContextPersistsThumbnailFields(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(7, 1))
 	mock.ExpectCommit()
 
-	service := newLocalUploadFileServiceWithImage(t, config.ImageConfig{ThumbnailWidth: 100, ThumbnailHeight: 100}, ".png")
+	service := newLocalUploadFileServiceWithImage(t, db, config.ImageConfig{ThumbnailWidth: 100, ThumbnailHeight: 100}, ".png")
 	file, err := service.UploadContext(context.Background(), systemMultipartFileHeader(t, "avatar.png", content), 42)
 	if err != nil {
 		t.Fatalf("UploadContext() error = %v", err)
@@ -118,7 +119,7 @@ func TestFileServiceUploadContextPersistsThumbnailFields(t *testing.T) {
 }
 
 func TestFileServiceUploadContextReusesExistingThumbnailFieldsForDuplicateHash(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	content := systemPNG(t, 400, 200)
 	hash := systemMD5Hex(content)
 
@@ -139,7 +140,7 @@ func TestFileServiceUploadContextReusesExistingThumbnailFieldsForDuplicateHash(t
 		WillReturnResult(sqlmock.NewResult(8, 1))
 	mock.ExpectCommit()
 
-	service := newLocalUploadFileServiceWithImage(t, config.ImageConfig{ThumbnailWidth: 100, ThumbnailHeight: 100}, ".png")
+	service := newLocalUploadFileServiceWithImage(t, db, config.ImageConfig{ThumbnailWidth: 100, ThumbnailHeight: 100}, ".png")
 	file, err := service.UploadContext(context.Background(), systemMultipartFileHeader(t, "avatar.png", content), 42)
 	if err != nil {
 		t.Fatalf("UploadContext() error = %v", err)
@@ -153,7 +154,7 @@ func TestFileServiceUploadContextReusesExistingThumbnailFieldsForDuplicateHash(t
 }
 
 func TestFileServiceDeleteFileContextDeletesThumbnailBestEffort(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	dir := t.TempDir()
 	originalPath := dir + "/avatar.png"
 	thumbnailPath := dir + "/thumbs/avatar_20x20.png"
@@ -185,6 +186,7 @@ func TestFileServiceDeleteFileContextDeletesThumbnailBestEffort(t *testing.T) {
 	mock.ExpectCommit()
 
 	service := &FileService{
+		fileDAO: *systemdao.NewFileDAO(db),
 		uploader: upload.NewUploaderWithConfig(config.UploadConfig{
 			StorageType: "local",
 			LocalPath:   dir,
@@ -200,7 +202,7 @@ func TestFileServiceDeleteFileContextDeletesThumbnailBestEffort(t *testing.T) {
 }
 
 func TestFileServiceDeleteFileContextKeepsSharedOriginalAndThumbnail(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	dir := t.TempDir()
 	originalPath := dir + "/avatar.png"
 	thumbnailPath := dir + "/thumbs/avatar_20x20.png"
@@ -232,6 +234,7 @@ func TestFileServiceDeleteFileContextKeepsSharedOriginalAndThumbnail(t *testing.
 	mock.ExpectCommit()
 
 	service := &FileService{
+		fileDAO: *systemdao.NewFileDAO(db),
 		uploader: upload.NewUploaderWithConfig(config.UploadConfig{
 			StorageType: "local",
 			LocalPath:   dir,
@@ -250,12 +253,12 @@ func TestFileServiceDeleteFileContextKeepsSharedOriginalAndThumbnail(t *testing.
 }
 
 func TestFileServiceGetFileListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := NewFileService().GetFileListContext(ctx, FileListRequest{
+	_, _, err := NewFileServiceWithDB(db).GetFileListContext(ctx, FileListRequest{
 		PageRequest: pagination.PageRequest{Page: 1, PageSize: 10},
 		DataScope:   authz.UserDataScope{Scope: authz.DataScopeAll},
 	})
@@ -265,12 +268,12 @@ func TestFileServiceGetFileListContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestFileServiceGetFileByIDInScopeContextReturnsNotFoundSentinel(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `files` WHERE id = ? ORDER BY `files`.`id` LIMIT ?")).
 		WithArgs(7, 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	_, err := NewFileService().GetFileByIDInScopeContext(context.Background(), 7, authz.UserDataScope{
+	_, err := NewFileServiceWithDB(db).GetFileByIDInScopeContext(context.Background(), 7, authz.UserDataScope{
 		Scope: authz.DataScopeAll,
 	})
 	if !errors.Is(err, ErrFileNotFoundOrPermissionDenied) {
@@ -279,13 +282,13 @@ func TestFileServiceGetFileByIDInScopeContextReturnsNotFoundSentinel(t *testing.
 }
 
 func TestFileServiceDeleteFileContextReturnsLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `files` WHERE id = ? ORDER BY `files`.`id` LIMIT ?")).
 		WithArgs(7, 1).
 		WillReturnError(lookupErr)
 
-	err := NewFileService().DeleteFileContext(context.Background(), 7, 1, authz.UserDataScope{
+	err := NewFileServiceWithDB(db).DeleteFileContext(context.Background(), 7, 1, authz.UserDataScope{
 		Scope: authz.DataScopeAll,
 	})
 	if !errors.Is(err, lookupErr) {
@@ -441,16 +444,17 @@ func TestFileServiceOpenFileContentContextDefaultsContentType(t *testing.T) {
 	}
 }
 
-func newLocalUploadFileService(t *testing.T, allowedTypes ...string) *FileService {
+func newLocalUploadFileService(t *testing.T, db *gorm.DB, allowedTypes ...string) *FileService {
 	t.Helper()
 
-	return newLocalUploadFileServiceWithImage(t, config.ImageConfig{}, allowedTypes...)
+	return newLocalUploadFileServiceWithImage(t, db, config.ImageConfig{}, allowedTypes...)
 }
 
-func newLocalUploadFileServiceWithImage(t *testing.T, imageCfg config.ImageConfig, allowedTypes ...string) *FileService {
+func newLocalUploadFileServiceWithImage(t *testing.T, db *gorm.DB, imageCfg config.ImageConfig, allowedTypes ...string) *FileService {
 	t.Helper()
 
 	return &FileService{
+		fileDAO: *systemdao.NewFileDAO(db),
 		uploader: upload.NewUploaderWithConfig(config.UploadConfig{
 			StorageType:   "local",
 			LocalPath:     t.TempDir(),

--- a/server/internal/service/system/login_log.go
+++ b/server/internal/service/system/login_log.go
@@ -18,6 +18,12 @@ type LoginLogService struct {
 	logDAO systemdao.LoginLogDAO
 }
 
+// NewLoginLogServiceWithDB builds a LoginLogService backed by an injected
+// database handle.
+func NewLoginLogServiceWithDB(db *gorm.DB) LoginLogService {
+	return LoginLogService{logDAO: *systemdao.NewLoginLogDAO(db)}
+}
+
 type LoginLogListRequest struct {
 	pagination.PageRequest
 	UserID    *uint               `form:"user_id" json:"user_id"`

--- a/server/internal/service/system/login_log_context_test.go
+++ b/server/internal/service/system/login_log_context_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 func TestLoginLogServiceGetLogListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&LoginLogService{}).GetLogListContext(ctx, LoginLogListRequest{
+	svc := NewLoginLogServiceWithDB(db)
+	_, _, err := (&svc).GetLogListContext(ctx, LoginLogListRequest{
 		PageRequest: pagination.PageRequest{Page: 1, PageSize: 10},
 		DataScope:   authz.UserDataScope{Scope: authz.DataScopeAll},
 	})
@@ -27,12 +28,13 @@ func TestLoginLogServiceGetLogListContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestLoginLogServiceGetUserLastLoginContextReturnsNotFoundSentinel(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `login_logs` WHERE user_id = ? AND status = 1 ORDER BY created_at DESC,`login_logs`.`id` LIMIT ?")).
 		WithArgs(7, 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	_, err := (&LoginLogService{}).GetUserLastLoginContext(context.Background(), 7)
+	svc := NewLoginLogServiceWithDB(db)
+	_, err := (&svc).GetUserLastLoginContext(context.Background(), 7)
 	if !errors.Is(err, ErrLoginLogNotFound) {
 		t.Fatalf("GetUserLastLoginContext() error = %v, want ErrLoginLogNotFound", err)
 	}

--- a/server/internal/service/system/menu.go
+++ b/server/internal/service/system/menu.go
@@ -14,6 +14,11 @@ type MenuService struct {
 	menuDAO systemdao.MenuDAO
 }
 
+// NewMenuServiceWithDB builds a MenuService backed by an injected database handle.
+func NewMenuServiceWithDB(db *gorm.DB) MenuService {
+	return MenuService{menuDAO: *systemdao.NewMenuDAO(db)}
+}
+
 type MenuListRequest struct {
 	pagination.PageRequest
 	Keyword string `json:"keyword" form:"keyword"`

--- a/server/internal/service/system/menu_context_test.go
+++ b/server/internal/service/system/menu_context_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestMenuServiceCreateMenuContextHonorsCanceledParentLookup(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&MenuService{}).CreateMenuContext(ctx, CreateMenuRequest{
+	svc := NewMenuServiceWithDB(db)
+	_, err := (&svc).CreateMenuContext(ctx, CreateMenuRequest{
 		Name:     "system",
 		Title:    "System",
 		ParentID: 1,
@@ -24,13 +25,14 @@ func TestMenuServiceCreateMenuContextHonorsCanceledParentLookup(t *testing.T) {
 }
 
 func TestMenuServiceCreateMenuContextReturnsParentLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `menus` WHERE `menus`.`id` = ? ORDER BY `menus`.`id` LIMIT ?")).
 		WithArgs(1, 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&MenuService{}).CreateMenuContext(context.Background(), CreateMenuRequest{
+	svc := NewMenuServiceWithDB(db)
+	_, err := (&svc).CreateMenuContext(context.Background(), CreateMenuRequest{
 		Name:     "system",
 		Title:    "System",
 		ParentID: 1,

--- a/server/internal/service/system/menu_seed.go
+++ b/server/internal/service/system/menu_seed.go
@@ -6,15 +6,16 @@ import (
 
 	systemdao "github.com/go-admin-kit/server/internal/dao/system"
 	"github.com/go-admin-kit/server/internal/model"
+	"gorm.io/gorm"
 )
 
 type MenuBootstrapResult struct {
 	Menus int `json:"menus"`
 }
 
-func BootstrapDefaultMenusContext(ctx context.Context) (MenuBootstrapResult, error) {
+func BootstrapDefaultMenusContext(ctx context.Context, db *gorm.DB) (MenuBootstrapResult, error) {
 	var result MenuBootstrapResult
-	created, err := (&systemdao.MenuSeedDAO{}).BootstrapDefaultMenusContext(ctx, DefaultMenus(), time.Now())
+	created, err := systemdao.NewMenuSeedDAO(db).BootstrapDefaultMenusContext(ctx, DefaultMenus(), time.Now())
 	result.Menus = created
 	return result, err
 }

--- a/server/internal/service/system/menu_user.go
+++ b/server/internal/service/system/menu_user.go
@@ -6,12 +6,22 @@ import (
 	"github.com/go-admin-kit/server/internal/dao/auth"
 	"github.com/go-admin-kit/server/internal/dao/system"
 	"github.com/go-admin-kit/server/internal/model"
+	"gorm.io/gorm"
 )
 
 // MenuUserService builds user menu trees.
 type MenuUserService struct {
 	menuDAO       system.MenuDAO
 	permissionDAO auth.PermissionDAO
+}
+
+// NewMenuUserServiceWithDB builds a MenuUserService backed by an injected
+// database handle.
+func NewMenuUserServiceWithDB(db *gorm.DB) MenuUserService {
+	return MenuUserService{
+		menuDAO:       *system.NewMenuDAO(db),
+		permissionDAO: *auth.NewPermissionDAO(db),
+	}
 }
 
 func (s *MenuUserService) GetUserMenuTreeContext(ctx context.Context, userID uint) ([]model.Menu, error) {

--- a/server/internal/service/system/notice.go
+++ b/server/internal/service/system/notice.go
@@ -15,6 +15,11 @@ type NoticeService struct {
 	noticeDAO systemdao.NoticeDAO
 }
 
+// NewNoticeServiceWithDB builds a NoticeService backed by an injected database handle.
+func NewNoticeServiceWithDB(db *gorm.DB) NoticeService {
+	return NoticeService{noticeDAO: *systemdao.NewNoticeDAO(db)}
+}
+
 type NoticeListRequest struct {
 	pagination.PageRequest
 	Type    *int8  `json:"type" form:"type"`

--- a/server/internal/service/system/notice_context_test.go
+++ b/server/internal/service/system/notice_context_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestNoticeServiceCreateContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&NoticeService{}).CreateContext(ctx, CreateNoticeRequest{
+	svc := NewNoticeServiceWithDB(db)
+	_, err := (&svc).CreateContext(ctx, CreateNoticeRequest{
 		Title:   "Maintenance",
 		Content: "Tonight",
 	}, 1, "admin")
@@ -23,13 +24,14 @@ func TestNoticeServiceCreateContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestNoticeServiceUpdateContextReturnsLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `notices` WHERE `notices`.`id` = ? ORDER BY `notices`.`id` LIMIT ?")).
 		WithArgs(7, 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&NoticeService{}).UpdateContext(context.Background(), 7, UpdateNoticeRequest{
+	svc := NewNoticeServiceWithDB(db)
+	_, err := (&svc).UpdateContext(context.Background(), 7, UpdateNoticeRequest{
 		Title: "Maintenance",
 	})
 	if !errors.Is(err, lookupErr) {

--- a/server/internal/service/system/operation_log.go
+++ b/server/internal/service/system/operation_log.go
@@ -16,6 +16,12 @@ type OperationLogService struct {
 	logDAO systemdao.OperationLogDAO
 }
 
+// NewOperationLogServiceWithDB builds an OperationLogService backed by an
+// injected database handle.
+func NewOperationLogServiceWithDB(db *gorm.DB) OperationLogService {
+	return OperationLogService{logDAO: *systemdao.NewOperationLogDAO(db)}
+}
+
 type OperationLogListRequest struct {
 	pagination.PageRequest
 	UserID    *uint               `form:"user_id" json:"user_id"`

--- a/server/internal/service/system/operation_log_context_test.go
+++ b/server/internal/service/system/operation_log_context_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 func TestOperationLogServiceGetLogListContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := (&OperationLogService{}).GetLogListContext(ctx, OperationLogListRequest{
+	svc := NewOperationLogServiceWithDB(db)
+	_, _, err := (&svc).GetLogListContext(ctx, OperationLogListRequest{
 		PageRequest: pagination.PageRequest{Page: 1, PageSize: 10},
 		DataScope:   authz.UserDataScope{Scope: authz.DataScopeAll},
 	})
@@ -27,12 +28,13 @@ func TestOperationLogServiceGetLogListContextHonorsCanceledContext(t *testing.T)
 }
 
 func TestOperationLogServiceGetLogByIDContextReturnsNotFoundSentinel(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `operation_logs` WHERE `operation_logs`.`id` = ? ORDER BY `operation_logs`.`id` LIMIT ?")).
 		WithArgs(7, 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	_, err := (&OperationLogService{}).GetLogByIDContext(context.Background(), 7)
+	svc := NewOperationLogServiceWithDB(db)
+	_, err := (&svc).GetLogByIDContext(context.Background(), 7)
 	if !errors.Is(err, ErrOperationLogNotFound) {
 		t.Fatalf("GetLogByIDContext() error = %v, want ErrOperationLogNotFound", err)
 	}

--- a/server/internal/service/system/permission.go
+++ b/server/internal/service/system/permission.go
@@ -11,13 +11,17 @@ import (
 )
 
 type PermissionService struct {
-	permissionDAO systemdao.PermissionManageDAO
+	permissionDAO      systemdao.PermissionManageDAO
+	permissionCacheDAO *systemdao.PermissionCacheDAO
 }
 
 // NewPermissionServiceWithDB builds a PermissionService backed by an injected
 // database handle.
 func NewPermissionServiceWithDB(db *gorm.DB) PermissionService {
-	return PermissionService{permissionDAO: *systemdao.NewPermissionManageDAO(db)}
+	return PermissionService{
+		permissionDAO:      *systemdao.NewPermissionManageDAO(db),
+		permissionCacheDAO: systemdao.NewPermissionCacheDAO(db),
+	}
 }
 
 type PermissionListRequest struct {
@@ -143,7 +147,7 @@ func (s *PermissionService) UpdatePermissionContext(ctx context.Context, id uint
 		return nil, err
 	}
 
-	if err := InvalidatePermissionCacheByPermissionsContext(ctx, id); err != nil {
+	if err := InvalidatePermissionCacheByPermissionsContext(ctx, s.permissionCacheDAO, id); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +162,7 @@ func (s *PermissionService) DeletePermissionContext(ctx context.Context, id uint
 		return err
 	}
 
-	if err := InvalidatePermissionCacheByPermissionsContext(ctx, id); err != nil {
+	if err := InvalidatePermissionCacheByPermissionsContext(ctx, s.permissionCacheDAO, id); err != nil {
 		return err
 	}
 

--- a/server/internal/service/system/permission.go
+++ b/server/internal/service/system/permission.go
@@ -14,6 +14,12 @@ type PermissionService struct {
 	permissionDAO systemdao.PermissionManageDAO
 }
 
+// NewPermissionServiceWithDB builds a PermissionService backed by an injected
+// database handle.
+func NewPermissionServiceWithDB(db *gorm.DB) PermissionService {
+	return PermissionService{permissionDAO: *systemdao.NewPermissionManageDAO(db)}
+}
+
 type PermissionListRequest struct {
 	pagination.PageRequest
 	Keyword string `json:"keyword" form:"keyword"`

--- a/server/internal/service/system/permission_test.go
+++ b/server/internal/service/system/permission_test.go
@@ -36,12 +36,13 @@ func TestPermissionRequestsExposeDescription(t *testing.T) {
 }
 
 func TestPermissionServiceCreatePermissionContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&PermissionService{}).CreatePermissionContext(ctx, CreatePermissionRequest{
+	svc := NewPermissionServiceWithDB(db)
+	_, err := (&svc).CreatePermissionContext(ctx, CreatePermissionRequest{
 		Name: "List Users",
 		Code: "system:user:list",
 		Type: 2,
@@ -52,13 +53,14 @@ func TestPermissionServiceCreatePermissionContextHonorsCanceledContext(t *testin
 }
 
 func TestPermissionServiceCreatePermissionContextReturnsCodeLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `permissions` WHERE code = ? ORDER BY `permissions`.`id` LIMIT ?")).
 		WithArgs("system:user:list", 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&PermissionService{}).CreatePermissionContext(context.Background(), CreatePermissionRequest{
+	svc := NewPermissionServiceWithDB(db)
+	_, err := (&svc).CreatePermissionContext(context.Background(), CreatePermissionRequest{
 		Name: "List Users",
 		Code: "system:user:list",
 		Type: 2,

--- a/server/internal/service/system/role.go
+++ b/server/internal/service/system/role.go
@@ -15,6 +15,11 @@ type RoleService struct {
 	roleDAO systemdao.RoleDAO
 }
 
+// NewRoleServiceWithDB builds a RoleService backed by an injected database handle.
+func NewRoleServiceWithDB(db *gorm.DB) RoleService {
+	return RoleService{roleDAO: *systemdao.NewRoleDAO(db)}
+}
+
 type RoleListRequest struct {
 	pagination.PageRequest
 	Keyword string `json:"keyword" form:"keyword"`

--- a/server/internal/service/system/role.go
+++ b/server/internal/service/system/role.go
@@ -12,12 +12,16 @@ import (
 )
 
 type RoleService struct {
-	roleDAO systemdao.RoleDAO
+	roleDAO            systemdao.RoleDAO
+	permissionCacheDAO *systemdao.PermissionCacheDAO
 }
 
 // NewRoleServiceWithDB builds a RoleService backed by an injected database handle.
 func NewRoleServiceWithDB(db *gorm.DB) RoleService {
-	return RoleService{roleDAO: *systemdao.NewRoleDAO(db)}
+	return RoleService{
+		roleDAO:            *systemdao.NewRoleDAO(db),
+		permissionCacheDAO: systemdao.NewPermissionCacheDAO(db),
+	}
 }
 
 type RoleListRequest struct {
@@ -135,7 +139,7 @@ func (s *RoleService) UpdateRoleContext(ctx context.Context, id uint, req Update
 		return nil, err
 	}
 
-	if err := InvalidatePermissionCacheByRolesContext(ctx, id); err != nil {
+	if err := InvalidatePermissionCacheByRolesContext(ctx, s.permissionCacheDAO, id); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +154,7 @@ func (s *RoleService) DeleteRoleContext(ctx context.Context, id uint) error {
 		return err
 	}
 
-	if err := InvalidatePermissionCacheByRolesContext(ctx, id); err != nil {
+	if err := InvalidatePermissionCacheByRolesContext(ctx, s.permissionCacheDAO, id); err != nil {
 		return err
 	}
 
@@ -170,7 +174,7 @@ func (s *RoleService) AssignPermissionsContext(ctx context.Context, roleID uint,
 		return err
 	}
 
-	return InvalidatePermissionCacheByRolesContext(ctx, roleID)
+	return InvalidatePermissionCacheByRolesContext(ctx, s.permissionCacheDAO, roleID)
 }
 
 func normalizeRoleDataScope(dataScope string) string {

--- a/server/internal/service/system/role_context_test.go
+++ b/server/internal/service/system/role_context_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func TestRoleServiceCreateRoleContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&RoleService{}).CreateRoleContext(ctx, CreateRoleRequest{
+	svc := NewRoleServiceWithDB(db)
+	_, err := (&svc).CreateRoleContext(ctx, CreateRoleRequest{
 		Name: "Manager",
 		Code: "manager",
 	})
@@ -23,13 +24,14 @@ func TestRoleServiceCreateRoleContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestRoleServiceCreateRoleContextReturnsCodeLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `roles` WHERE code = ? ORDER BY `roles`.`id` LIMIT ?")).
 		WithArgs("manager", 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&RoleService{}).CreateRoleContext(context.Background(), CreateRoleRequest{
+	svc := NewRoleServiceWithDB(db)
+	_, err := (&svc).CreateRoleContext(context.Background(), CreateRoleRequest{
 		Name: "Manager",
 		Code: "manager",
 	})

--- a/server/internal/service/system/setting.go
+++ b/server/internal/service/system/setting.go
@@ -18,6 +18,12 @@ type SettingService struct {
 	emailInvalidator   runtimeconfig.EmailNotificationInvalidator
 }
 
+// NewSettingServiceWithDB builds a SettingService backed by an injected
+// database handle. Invalidators keep their default implementations.
+func NewSettingServiceWithDB(db *gorm.DB) SettingService {
+	return SettingService{settingDAO: *systemdao.NewSettingDAO(db)}
+}
+
 const runtimeConfigInvalidationTimeout = 2 * time.Second
 
 type UpsertSettingRequest struct {

--- a/server/internal/service/system/setting_context_test.go
+++ b/server/internal/service/system/setting_context_test.go
@@ -16,21 +16,23 @@ import (
 )
 
 func TestSettingServiceGetSettingContextMapsNotFound(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `system_settings` WHERE setting_key = ? ORDER BY `system_settings`.`setting_key` LIMIT ?")).
 		WithArgs("security.password_policy", 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	_, err := (&SettingService{}).GetSettingContext(context.Background(), "security.password_policy")
+	svc := NewSettingServiceWithDB(db)
+	_, err := (&svc).GetSettingContext(context.Background(), "security.password_policy")
 	if !errors.Is(err, ErrSystemSettingNotFound) {
 		t.Fatalf("GetSettingContext() error = %v, want ErrSystemSettingNotFound", err)
 	}
 }
 
 func TestSettingServiceUpsertSettingContextRejectsInvalidKey(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
-	_, err := (&SettingService{}).UpsertSettingContext(context.Background(), UpsertSettingRequest{
+	svc := NewSettingServiceWithDB(db)
+	_, err := (&svc).UpsertSettingContext(context.Background(), UpsertSettingRequest{
 		SettingKey: "security password",
 		ValueJSON:  map[string]any{"password_max_age_days": 90},
 	})
@@ -40,21 +42,22 @@ func TestSettingServiceUpsertSettingContextRejectsInvalidKey(t *testing.T) {
 }
 
 func TestSettingServiceDeleteSettingContextMapsNotFound(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `system_settings` WHERE setting_key = ?")).
 		WithArgs("security.policy").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	err := (&SettingService{}).DeleteSettingContext(context.Background(), "security.policy")
+	svc := NewSettingServiceWithDB(db)
+	err := (&svc).DeleteSettingContext(context.Background(), "security.policy")
 	if !errors.Is(err, ErrSystemSettingNotFound) {
 		t.Fatalf("DeleteSettingContext() error = %v, want ErrSystemSettingNotFound", err)
 	}
 }
 
 func TestSettingServiceUpsertSecurityPolicyRefreshesRuntimeConfig(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO `system_settings`").
 		WithArgs(runtimeconfig.SecurityPolicySettingKey, sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -62,7 +65,9 @@ func TestSettingServiceUpsertSecurityPolicyRefreshesRuntimeConfig(t *testing.T) 
 	mock.ExpectCommit()
 
 	invalidator := &stubRuntimeConfigInvalidator{}
-	_, err := (&SettingService{runtimeInvalidator: invalidator}).UpsertSettingContext(context.Background(), UpsertSettingRequest{
+	svc := NewSettingServiceWithDB(db)
+	svc.runtimeInvalidator = invalidator
+	_, err := (&svc).UpsertSettingContext(context.Background(), UpsertSettingRequest{
 		SettingKey: runtimeconfig.SecurityPolicySettingKey,
 		ValueJSON:  map[string]any{"password_history_count": 3},
 	})
@@ -75,7 +80,7 @@ func TestSettingServiceUpsertSecurityPolicyRefreshesRuntimeConfig(t *testing.T) 
 }
 
 func TestSettingServiceDeleteSecurityPolicyRefreshesRuntimeConfig(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `system_settings` WHERE setting_key = ?")).
 		WithArgs(runtimeconfig.SecurityPolicySettingKey).
@@ -83,7 +88,9 @@ func TestSettingServiceDeleteSecurityPolicyRefreshesRuntimeConfig(t *testing.T) 
 	mock.ExpectCommit()
 
 	invalidator := &stubRuntimeConfigInvalidator{}
-	err := (&SettingService{runtimeInvalidator: invalidator}).DeleteSettingContext(context.Background(), runtimeconfig.SecurityPolicySettingKey)
+	svc := NewSettingServiceWithDB(db)
+	svc.runtimeInvalidator = invalidator
+	err := (&svc).DeleteSettingContext(context.Background(), runtimeconfig.SecurityPolicySettingKey)
 	if err != nil {
 		t.Fatalf("DeleteSettingContext() error = %v", err)
 	}
@@ -93,7 +100,7 @@ func TestSettingServiceDeleteSecurityPolicyRefreshesRuntimeConfig(t *testing.T) 
 }
 
 func TestSettingServiceUpsertEmailNotificationRefreshesRuntimeConfig(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO `system_settings`").
 		WithArgs(runtimeconfig.EmailNotificationSettingKey, sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -101,7 +108,9 @@ func TestSettingServiceUpsertEmailNotificationRefreshesRuntimeConfig(t *testing.
 	mock.ExpectCommit()
 
 	emailInvalidator := &stubRuntimeConfigInvalidator{}
-	_, err := (&SettingService{emailInvalidator: emailInvalidator}).UpsertSettingContext(context.Background(), UpsertSettingRequest{
+	svc := NewSettingServiceWithDB(db)
+	svc.emailInvalidator = emailInvalidator
+	_, err := (&svc).UpsertSettingContext(context.Background(), UpsertSettingRequest{
 		SettingKey: runtimeconfig.EmailNotificationSettingKey,
 		ValueJSON:  map[string]any{"enabled": true},
 	})
@@ -151,7 +160,7 @@ func TestSettingServiceUpsertRuntimeConfigPublishesInvalidation(t *testing.T) {
 				}
 			}()
 
-			mock := setupSystemUserServiceContextTestDB(t)
+			db, mock := setupSystemUserServiceContextTestDB(t)
 			mock.ExpectBegin()
 			mock.ExpectExec("INSERT INTO `system_settings`").
 				WithArgs(tt.key, sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -159,7 +168,7 @@ func TestSettingServiceUpsertRuntimeConfigPublishesInvalidation(t *testing.T) {
 			mock.ExpectCommit()
 
 			invalidator := &stubRuntimeConfigInvalidator{}
-			service := &SettingService{}
+			service := NewSettingServiceWithDB(db)
 			if tt.key == runtimeconfig.SecurityPolicySettingKey {
 				service.runtimeInvalidator = invalidator
 			} else {
@@ -196,7 +205,7 @@ func TestSettingServiceUpsertRuntimeConfigIgnoresPublishFailure(t *testing.T) {
 		redisstore.Client = oldClient
 	})
 
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO `system_settings`").
 		WithArgs(runtimeconfig.SecurityPolicySettingKey, sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -204,7 +213,9 @@ func TestSettingServiceUpsertRuntimeConfigIgnoresPublishFailure(t *testing.T) {
 	mock.ExpectCommit()
 
 	invalidator := &stubRuntimeConfigInvalidator{}
-	_, err := (&SettingService{runtimeInvalidator: invalidator}).UpsertSettingContext(context.Background(), UpsertSettingRequest{
+	svc := NewSettingServiceWithDB(db)
+	svc.runtimeInvalidator = invalidator
+	_, err := (&svc).UpsertSettingContext(context.Background(), UpsertSettingRequest{
 		SettingKey: runtimeconfig.SecurityPolicySettingKey,
 		ValueJSON:  map[string]any{"password_history_count": 3},
 	})

--- a/server/internal/service/system/user.go
+++ b/server/internal/service/system/user.go
@@ -19,6 +19,11 @@ type UserService struct {
 	userDAO systemdao.UserDAO
 }
 
+// NewUserServiceWithDB builds a UserService backed by an injected database handle.
+func NewUserServiceWithDB(db *gorm.DB) UserService {
+	return UserService{userDAO: *systemdao.NewUserDAO(db)}
+}
+
 type UserListRequest struct {
 	pagination.PageRequest
 	Keyword   string              `json:"keyword" form:"keyword"`

--- a/server/internal/service/system/user_context_test.go
+++ b/server/internal/service/system/user_context_test.go
@@ -7,19 +7,19 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-admin-kit/server/internal/pkg/database"
 	authsvc "github.com/go-admin-kit/server/internal/service/auth"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
 func TestUserServiceCreateUserContextHonorsCanceledContext(t *testing.T) {
-	setupSystemUserServiceContextTestDB(t)
+	db, _ := setupSystemUserServiceContextTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := (&UserService{}).CreateUserContext(ctx, CreateUserRequest{
+	svc := NewUserServiceWithDB(db)
+	_, err := svc.CreateUserContext(ctx, CreateUserRequest{
 		Username: "alice",
 		Password: "Secret123",
 	})
@@ -29,13 +29,14 @@ func TestUserServiceCreateUserContextHonorsCanceledContext(t *testing.T) {
 }
 
 func TestUserServiceCreateUserContextReturnsUsernameLookupError(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	lookupErr := errors.New("database lookup failed")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE username = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs("alice", 1).
 		WillReturnError(lookupErr)
 
-	_, err := (&UserService{}).CreateUserContext(context.Background(), CreateUserRequest{
+	svc := NewUserServiceWithDB(db)
+	_, err := svc.CreateUserContext(context.Background(), CreateUserRequest{
 		Username: "alice",
 		Password: "Secret123",
 	})
@@ -45,12 +46,13 @@ func TestUserServiceCreateUserContextReturnsUsernameLookupError(t *testing.T) {
 }
 
 func TestUserServiceCreateUserContextRejectsWeakPassword(t *testing.T) {
-	mock := setupSystemUserServiceContextTestDB(t)
+	db, mock := setupSystemUserServiceContextTestDB(t)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `users` WHERE username = ? ORDER BY `users`.`id` LIMIT ?")).
 		WithArgs("alice", 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password"}))
 
-	_, err := (&UserService{}).CreateUserContext(context.Background(), CreateUserRequest{
+	svc := NewUserServiceWithDB(db)
+	_, err := svc.CreateUserContext(context.Background(), CreateUserRequest{
 		Username: "alice",
 		Password: "short",
 	})
@@ -60,10 +62,9 @@ func TestUserServiceCreateUserContextRejectsWeakPassword(t *testing.T) {
 	}
 }
 
-func setupSystemUserServiceContextTestDB(t *testing.T) sqlmock.Sqlmock {
+func setupSystemUserServiceContextTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
-	oldDB := database.DB
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("open sqlmock db: %v", err)
@@ -76,14 +77,12 @@ func setupSystemUserServiceContextTestDB(t *testing.T) sqlmock.Sqlmock {
 		t.Fatalf("open gorm sqlmock db: %v", err)
 	}
 
-	database.DB = db
 	t.Cleanup(func() {
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet database expectations: %v", err)
 		}
 		_ = sqlDB.Close()
-		database.DB = oldDB
 	})
 
-	return mock
+	return db, mock
 }

--- a/tdesign-vue-go/package-lock.json
+++ b/tdesign-vue-go/package-lock.json
@@ -5933,16 +5933,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6252,9 +6252,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"


### PR DESCRIPTION
## Summary

Introduces a dependency-injected composition root and threads explicit persistence/service dependencies through the API, service, DAO, and middleware layers—removing reliance on the ambient `database.DB` global. Tests across all layers are migrated to inject their own `*gorm.DB` (sqlmock) instead of mutating and restoring the global.

## Changes

- **Composition root**: route composition now wires services/APIs through constructors instead of zero-value structs.
- **Constructors**: added `NewXxxServiceWithDB` / DB constructors for auth, system, and monitor services; injected auth API services, system API services, monitor services, and health API clients.
- **Middleware & persistence**: injected auth middleware persistence, operation-log recorder, authz persistence stores, and the runtime security-policy store.
- **Test migration**: DAO, API, authz, and service-level tests now build components via injected DBs; shared test helpers return `(*gorm.DB, sqlmock.Sqlmock)` rather than swapping the global. Route composition is guarded against zero-value API constructors.

## Testing

- `go build ./...`
- `go vet ./...`
- full `go test` suite (auth and system packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)