### PR TITLE
修复（认证与监控契约）：加固刷新协调并完善 OpenAPI 生成链路

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,47 @@ jobs:
           cache: npm
           cache-dependency-path: microservices/web/package-lock.json
       - run: npm ci
-      - run: npm audit --omit=dev
+      - name: Audit production dependencies
+        # 当前应用仅使用 BrowserRouter；GHSA-qwww-vcr4-c8h2 针对未启用的 RSC
+        # action 请求路径，待上游提供安全版本后移除该临时 allowlist。
+        run: |
+          set +e
+          npm audit --omit=dev --json > npm-audit.json
+          audit_status=$?
+          set -e
+          node --input-type=module <<'NODE'
+          import { readFileSync } from 'node:fs';
+
+          const report = JSON.parse(readFileSync('npm-audit.json', 'utf8'));
+          const allowed = new Set(['GHSA-qwww-vcr4-c8h2']);
+          const advisories = Object.values(report.vulnerabilities ?? {})
+            .flatMap((entry) => entry.via ?? [])
+            .filter((entry) => typeof entry === 'object' && entry.url);
+          const unexpected = advisories.filter((entry) => {
+            const advisoryId = entry.url.split('/').pop();
+            return !allowed.has(advisoryId);
+          });
+
+          if (unexpected.length > 0) {
+            console.error('发现未纳入审查的生产依赖安全公告：');
+            for (const entry of unexpected) {
+              console.error(`- ${entry.url} (${entry.severity})`);
+            }
+            process.exit(1);
+          }
+
+          for (const entry of advisories) {
+            console.warn(`已记录临时 allowlist 公告：${entry.url} (${entry.severity})`);
+          }
+          NODE
+          audit_check_status=$?
+          rm -f npm-audit.json
+          if [ "$audit_check_status" -ne 0 ]; then
+            exit "$audit_check_status"
+          fi
+          if [ "$audit_status" -ne 0 ]; then
+            echo "npm audit 仅报告了已明确 allowlist 的公告。"
+          fi
       - run: npm run lint
       - run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           npm run test:smoke:unit
 
       - name: Check generated OpenAPI is committed
-        run: git diff --exit-code -- microservices/services/monitor/docs/openapi.json
+        run: git diff --exit-code -- microservices/services/monitor/docs/openapi.json microservices/web/src/api/generated/schema.d.ts
 
   monitor-service:
     name: Monitor Service

--- a/microservices/scripts/generate-openapi-types.mjs
+++ b/microservices/scripts/generate-openapi-types.mjs
@@ -117,7 +117,8 @@ for (const methods of Object.values(spec.paths || {})) {
       lines.push('    };');
     }
     if (operation.requestBody) {
-      lines.push('    requestBody: {');
+      const optional = operation.requestBody.required === true ? '' : '?';
+      lines.push(`    requestBody${optional}: {`);
       lines.push('      content: {');
       for (const [contentType, mediaType] of Object.entries(operation.requestBody.content || {})) {
         lines.push(`        ${JSON.stringify(contentType)}: ${schemaToTs(mediaType.schema)};`);

--- a/microservices/services/monitor/docs/openapi.json
+++ b/microservices/services/monitor/docs/openapi.json
@@ -481,8 +481,20 @@
             "BearerAuth": []
           }
         ],
+        "parameters": [
+          {
+            "name": "retention_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          }
+        ],
         "requestBody": {
-          "required": true,
+          "required": false,
           "content": {
             "application/json": {
               "schema": {
@@ -522,8 +534,28 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -580,7 +612,11 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "enum": [
+                0,
+                1
+              ]
             }
           }
         ],
@@ -615,8 +651,28 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -679,8 +735,28 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -711,7 +787,8 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1
             }
           }
         ],
@@ -746,8 +823,28 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -777,7 +874,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "$ref": "#/components/schemas/JobHeartbeatsEnvelope"
                 }
               }
             }
@@ -802,8 +899,28 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -869,8 +986,38 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Scheduled job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -944,8 +1091,38 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Scheduled job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -1011,8 +1188,38 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Scheduled job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -1078,8 +1285,38 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Scheduled job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -1145,8 +1382,38 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Scheduled job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -1201,8 +1468,28 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Monitor dependency unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -1249,6 +1536,16 @@
           },
           "401": {
             "description": "Unauthenticated or session expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
             "content": {
               "application/json": {
                 "schema": {
@@ -1313,6 +1610,16 @@
               }
             }
           },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {
@@ -1344,7 +1651,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "$ref": "#/components/schemas/ServicesHealthEnvelope"
                 }
               }
             }
@@ -1361,6 +1668,16 @@
           },
           "401": {
             "description": "Unauthenticated or session expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
             "content": {
               "application/json": {
                 "schema": {
@@ -1387,6 +1704,10 @@
     "schemas": {
       "ApiResponse": {
         "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
         "properties": {
           "code": {
             "type": "integer"
@@ -1554,6 +1875,111 @@
           }
         }
       },
+      "JobHeartbeat": {
+        "type": "object",
+        "required": [
+          "id",
+          "job_key",
+          "service",
+          "description",
+          "interval_sec",
+          "last_run_at",
+          "last_status",
+          "last_error",
+          "last_duration_ms",
+          "runs",
+          "fails",
+          "updated_at",
+          "stale"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "fails": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "interval_sec": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "job_key": {
+            "type": "string"
+          },
+          "last_duration_ms": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "last_run_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_status": {
+            "type": "string"
+          },
+          "runs": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "service": {
+            "type": "string"
+          },
+          "stale": {
+            "type": "boolean"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "JobHeartbeatsEnvelope": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "data"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "data": {
+            "$ref": "#/components/schemas/JobHeartbeatsResponse"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "JobHeartbeatsResponse": {
+        "type": "object",
+        "required": [
+          "list",
+          "total"
+        ],
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JobHeartbeat"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
       "JobListEnvelope": {
         "type": "object",
         "required": [
@@ -1608,7 +2034,8 @@
         "properties": {
           "retention_days": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "minimum": 1
           }
         }
       },
@@ -2383,6 +2810,83 @@
           },
           "platform": {
             "type": "string"
+          }
+        }
+      },
+      "ServiceHealthRow": {
+        "type": "object",
+        "required": [
+          "name",
+          "ok",
+          "http_code",
+          "latency_ms"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "http_code": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ServicesHealthEnvelope": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "data"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ServicesHealthResponse"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "ServicesHealthResponse": {
+        "type": "object",
+        "required": [
+          "list",
+          "total",
+          "healthy",
+          "checked_at"
+        ],
+        "properties": {
+          "checked_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "healthy": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceHealthRow"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       }

--- a/microservices/services/monitor/internal/openapi/schemas.go
+++ b/microservices/services/monitor/internal/openapi/schemas.go
@@ -1,10 +1,13 @@
 package openapi
 
 type routeContract struct {
-	RequestSchema  string
-	ResponseSchema string
-	QueryParams    []Parameter
-	NoRequestBody  bool
+	RequestSchema       string
+	ResponseSchema      string
+	QueryParams         []Parameter
+	NoRequestBody       bool
+	OptionalRequestBody bool
+	UnavailableResponse bool
+	NotFoundResponse    bool
 }
 
 func coreSchemas() map[string]Schema {
@@ -35,7 +38,7 @@ func coreSchemas() map[string]Schema {
 			"concurrent":      integerSchema(),
 		}, []string{"name", "cron_expression", "invoke_target"}),
 		"JobLogCleanupRequest": objectSchema(map[string]Schema{
-			"retention_days": integerSchema(),
+			"retention_days": minimumIntegerSchema(1),
 		}, nil),
 		"JobLogCleanupResult": objectSchema(map[string]Schema{
 			"retention_days": integerSchema(),
@@ -62,6 +65,41 @@ func coreSchemas() map[string]Schema {
 			"window_hours":  integerSchema(),
 			"checked_at":    dateTimeSchema(),
 		}, []string{"total", "enabled", "paused", "recent_failed", "abnormal_jobs", "window_hours", "checked_at"}),
+		"JobHeartbeat": objectSchema(map[string]Schema{
+			"id":               integerSchema(),
+			"job_key":          stringSchema(),
+			"service":          stringSchema(),
+			"description":      stringSchema(),
+			"interval_sec":     integerSchema(),
+			"last_run_at":      dateTimeSchema(),
+			"last_status":      stringSchema(),
+			"last_error":       stringSchema(),
+			"last_duration_ms": integerSchema(),
+			"runs":             integerSchema(),
+			"fails":            integerSchema(),
+			"updated_at":       dateTimeSchema(),
+			"stale":            booleanSchema(),
+		}, []string{
+			"id", "job_key", "service", "description", "interval_sec", "last_run_at",
+			"last_status", "last_error", "last_duration_ms", "runs", "fails", "updated_at", "stale",
+		}),
+		"JobHeartbeatsResponse": objectSchema(map[string]Schema{
+			"list":  arraySchema(refSchema("JobHeartbeat")),
+			"total": integerSchema(),
+		}, []string{"list", "total"}),
+		"ServiceHealthRow": objectSchema(map[string]Schema{
+			"name":       stringSchema(),
+			"ok":         booleanSchema(),
+			"http_code":  integerSchema(),
+			"latency_ms": integerSchema(),
+			"error":      stringSchema(),
+		}, []string{"name", "ok", "http_code", "latency_ms"}),
+		"ServicesHealthResponse": objectSchema(map[string]Schema{
+			"list":       arraySchema(refSchema("ServiceHealthRow")),
+			"total":      integerSchema(),
+			"healthy":    integerSchema(),
+			"checked_at": dateTimeSchema(),
+		}, []string{"list", "total", "healthy", "checked_at"}),
 		"ServerOSInfo": objectSchema(map[string]Schema{
 			"go_os":         stringSchema(),
 			"arch":          stringSchema(),
@@ -212,7 +250,9 @@ func coreSchemas() map[string]Schema {
 		"JobEnvelope":                 "ScheduledJob",
 		"JobListEnvelope":             "JobListResponse",
 		"JobHealthEnvelope":           "JobHealthCheck",
+		"JobHeartbeatsEnvelope":       "JobHeartbeatsResponse",
 		"JobLogCleanupResultEnvelope": "JobLogCleanupResult",
+		"ServicesHealthEnvelope":      "ServicesHealthResponse",
 		"ServerInfoEnvelope":          "ServerInfo",
 		"MySQLInfoEnvelope":           "MySQLInfo",
 		"RedisInfoEnvelope":           "RedisInfo",
@@ -226,17 +266,19 @@ func coreSchemas() map[string]Schema {
 func contractFor(method, path string) (routeContract, bool) {
 	contracts := map[string]routeContract{
 		"GET /api/v1/monitor/server":            {ResponseSchema: "ServerInfoEnvelope"},
-		"GET /api/v1/monitor/mysql":             {ResponseSchema: "MySQLInfoEnvelope"},
+		"GET /api/v1/monitor/mysql":             {ResponseSchema: "MySQLInfoEnvelope", UnavailableResponse: true},
 		"GET /api/v1/monitor/redis":             {ResponseSchema: "RedisInfoEnvelope"},
-		"GET /api/v1/monitor/jobs":              {ResponseSchema: "JobListEnvelope", QueryParams: pagingQueryParams("name", "status")},
-		"GET /api/v1/monitor/jobs/health":       {ResponseSchema: "JobHealthEnvelope", QueryParams: []Parameter{queryParam("window_hours", integerSchema())}},
-		"POST /api/v1/monitor/jobs":             {RequestSchema: "SaveJobRequest", ResponseSchema: "JobEnvelope"},
-		"PUT /api/v1/monitor/jobs/{id}":         {RequestSchema: "SaveJobRequest", ResponseSchema: "JobEnvelope"},
-		"DELETE /api/v1/monitor/jobs/{id}":      {ResponseSchema: "EmptyEnvelope"},
-		"POST /api/v1/monitor/jobs/{id}/start":  {ResponseSchema: "EmptyEnvelope", NoRequestBody: true},
-		"POST /api/v1/monitor/jobs/{id}/stop":   {ResponseSchema: "EmptyEnvelope", NoRequestBody: true},
-		"POST /api/v1/monitor/jobs/{id}/run":    {ResponseSchema: "EmptyEnvelope", NoRequestBody: true},
-		"POST /api/v1/monitor/job-logs/cleanup": {RequestSchema: "JobLogCleanupRequest", ResponseSchema: "JobLogCleanupResultEnvelope"},
+		"GET /api/v1/monitor/jobs":              {ResponseSchema: "JobListEnvelope", QueryParams: pagingQueryParams("name", "status"), UnavailableResponse: true},
+		"GET /api/v1/monitor/jobs/health":       {ResponseSchema: "JobHealthEnvelope", QueryParams: []Parameter{queryParam("window_hours", minimumIntegerSchema(1))}, UnavailableResponse: true},
+		"GET /api/v1/monitor/jobs/heartbeats":   {ResponseSchema: "JobHeartbeatsEnvelope", UnavailableResponse: true},
+		"GET /api/v1/monitor/services":          {ResponseSchema: "ServicesHealthEnvelope"},
+		"POST /api/v1/monitor/jobs":             {RequestSchema: "SaveJobRequest", ResponseSchema: "JobEnvelope", UnavailableResponse: true},
+		"PUT /api/v1/monitor/jobs/{id}":         {RequestSchema: "SaveJobRequest", ResponseSchema: "JobEnvelope", UnavailableResponse: true, NotFoundResponse: true},
+		"DELETE /api/v1/monitor/jobs/{id}":      {ResponseSchema: "EmptyEnvelope", UnavailableResponse: true, NotFoundResponse: true},
+		"POST /api/v1/monitor/jobs/{id}/start":  {ResponseSchema: "EmptyEnvelope", NoRequestBody: true, UnavailableResponse: true, NotFoundResponse: true},
+		"POST /api/v1/monitor/jobs/{id}/stop":   {ResponseSchema: "EmptyEnvelope", NoRequestBody: true, UnavailableResponse: true, NotFoundResponse: true},
+		"POST /api/v1/monitor/jobs/{id}/run":    {ResponseSchema: "EmptyEnvelope", NoRequestBody: true, UnavailableResponse: true, NotFoundResponse: true},
+		"POST /api/v1/monitor/job-logs/cleanup": {RequestSchema: "JobLogCleanupRequest", ResponseSchema: "JobLogCleanupResultEnvelope", QueryParams: []Parameter{queryParam("retention_days", minimumIntegerSchema(1))}, OptionalRequestBody: true, UnavailableResponse: true},
 	}
 	contract, ok := contracts[method+" "+path]
 	return contract, ok
@@ -283,8 +325,20 @@ func integerSchema() Schema {
 	return Schema{Type: "integer", Format: "int64"}
 }
 
+func integerEnumSchema(values ...int) Schema {
+	return Schema{Type: "integer", Format: "int64", Enum: values}
+}
+
+func minimumIntegerSchema(minimum int) Schema {
+	return Schema{Type: "integer", Format: "int64", Minimum: &minimum}
+}
+
 func numberSchema() Schema {
 	return Schema{Type: "number", Format: "double"}
+}
+
+func booleanSchema() Schema {
+	return Schema{Type: "boolean"}
 }
 
 func arraySchema(item Schema) Schema {
@@ -303,7 +357,7 @@ func pagingQueryParams(names ...string) []Parameter {
 	for _, name := range names {
 		schema := stringSchema()
 		if name == "status" {
-			schema = integerSchema()
+			schema = integerEnumSchema(0, 1)
 		}
 		params = append(params, queryParam(name, schema))
 	}

--- a/microservices/services/monitor/internal/openapi/spec.go
+++ b/microservices/services/monitor/internal/openapi/spec.go
@@ -81,7 +81,8 @@ type Schema struct {
 	Format               string            `json:"format,omitempty"`
 	Description          string            `json:"description,omitempty"`
 	Required             []string          `json:"required,omitempty"`
-	Enum                 []string          `json:"enum,omitempty"`
+	Enum                 []int             `json:"enum,omitempty"`
+	Minimum              *int              `json:"minimum,omitempty"`
 	Properties           map[string]Schema `json:"properties,omitempty"`
 	Items                *Schema           `json:"items,omitempty"`
 	AdditionalProperties any               `json:"additionalProperties,omitempty"`
@@ -108,6 +109,10 @@ func BuildSpec(routes []gin.RouteInfo, opts Options) Spec {
 			Schemas: map[string]Schema{
 				"ApiResponse": {
 					Type: "object",
+					Required: []string{
+						"code",
+						"message",
+					},
 					Properties: map[string]Schema{
 						"code":    {Type: "integer"},
 						"message": {Type: "string"},
@@ -189,11 +194,14 @@ func buildOperation(method, path string) Operation {
 	if !isPublicRoute(method, path) {
 		op.Security = []map[string][]string{{"BearerAuth": {}}}
 	}
+	if strings.HasPrefix(path, "/api/v1/monitor/") {
+		op.Responses["403"] = jsonResponse("Insufficient permissions", refSchema("ApiResponse"))
+	}
 	if hasContract && len(contract.QueryParams) > 0 {
 		op.Parameters = append(op.Parameters, contract.QueryParams...)
 	}
 	if hasContract && contract.RequestSchema != "" {
-		op.RequestBody = jsonRequestBody(refSchema(contract.RequestSchema))
+		op.RequestBody = jsonRequestBody(refSchema(contract.RequestSchema), !contract.OptionalRequestBody)
 	} else if hasJSONRequestBody(method, path) && (!hasContract || !contract.NoRequestBody) {
 		op.RequestBody = &RequestBody{
 			Required: true,
@@ -204,6 +212,12 @@ func buildOperation(method, path string) Operation {
 	}
 	if hasContract && contract.ResponseSchema != "" {
 		op.Responses["200"] = jsonResponse("Request succeeded", refSchema(contract.ResponseSchema))
+	}
+	if hasContract && contract.UnavailableResponse {
+		op.Responses["503"] = jsonResponse("Monitor dependency unavailable", refSchema("ApiResponse"))
+	}
+	if hasContract && contract.NotFoundResponse {
+		op.Responses["404"] = jsonResponse("Scheduled job not found", refSchema("ApiResponse"))
 	}
 	if path == "/api/v1/metrics" {
 		op.Responses["200"] = Response{
@@ -216,9 +230,9 @@ func buildOperation(method, path string) Operation {
 	return op
 }
 
-func jsonRequestBody(schema Schema) *RequestBody {
+func jsonRequestBody(schema Schema, required bool) *RequestBody {
 	return &RequestBody{
-		Required: true,
+		Required: required,
 		Content: map[string]MediaType{
 			"application/json": {Schema: schema},
 		},

--- a/microservices/services/monitor/internal/openapi/spec_test.go
+++ b/microservices/services/monitor/internal/openapi/spec_test.go
@@ -1,7 +1,9 @@
 package openapi
 
 import (
+	"encoding/json"
 	"os"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -75,6 +77,7 @@ func TestBuildSpecDocumentsErrorCodeField(t *testing.T) {
 	spec := BuildSpec(nil, Options{})
 
 	apiResponse := spec.Components.Schemas["ApiResponse"]
+	assertRequired(t, apiResponse.Required, "code", "message")
 	errorCode, ok := apiResponse.Properties["error_code"]
 	if !ok {
 		t.Fatal("ApiResponse schema missing error_code")
@@ -82,6 +85,74 @@ func TestBuildSpecDocumentsErrorCodeField(t *testing.T) {
 	if errorCode.Type != "string" {
 		t.Fatalf("error_code type = %q, want string", errorCode.Type)
 	}
+}
+
+func TestBuildSpecDocumentsMonitorAuthorizationAndJobValidation(t *testing.T) {
+	spec := BuildSpec([]gin.RouteInfo{
+		{Method: "GET", Path: "/api/v1/monitor/server"},
+		{Method: "GET", Path: "/api/v1/monitor/services"},
+		{Method: "GET", Path: "/api/v1/monitor/mysql"},
+		{Method: "GET", Path: "/api/v1/monitor/redis"},
+		{Method: "GET", Path: "/api/v1/monitor/jobs"},
+		{Method: "GET", Path: "/api/v1/monitor/jobs/health"},
+		{Method: "GET", Path: "/api/v1/monitor/jobs/heartbeats"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs"},
+		{Method: "PUT", Path: "/api/v1/monitor/jobs/:id"},
+		{Method: "DELETE", Path: "/api/v1/monitor/jobs/:id"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs/:id/start"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs/:id/stop"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs/:id/run"},
+		{Method: "POST", Path: "/api/v1/monitor/job-logs/cleanup"},
+	}, Options{})
+
+	for _, route := range []struct {
+		method string
+		path   string
+	}{
+		{method: "get", path: "/api/v1/monitor/server"},
+		{method: "get", path: "/api/v1/monitor/services"},
+		{method: "get", path: "/api/v1/monitor/mysql"},
+		{method: "get", path: "/api/v1/monitor/redis"},
+		{method: "get", path: "/api/v1/monitor/jobs"},
+		{method: "get", path: "/api/v1/monitor/jobs/health"},
+		{method: "get", path: "/api/v1/monitor/jobs/heartbeats"},
+		{method: "post", path: "/api/v1/monitor/jobs"},
+		{method: "put", path: "/api/v1/monitor/jobs/{id}"},
+		{method: "delete", path: "/api/v1/monitor/jobs/{id}"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/start"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/stop"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/run"},
+		{method: "post", path: "/api/v1/monitor/job-logs/cleanup"},
+	} {
+		assertJSONResponseRefAtStatus(t, spec.Paths[route.path][route.method], "403", "#/components/schemas/ApiResponse")
+	}
+
+	for _, route := range []struct {
+		method string
+		path   string
+	}{
+		{method: "put", path: "/api/v1/monitor/jobs/{id}"},
+		{method: "delete", path: "/api/v1/monitor/jobs/{id}"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/start"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/stop"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/run"},
+	} {
+		assertJSONResponseRefAtStatus(t, spec.Paths[route.path][route.method], "404", "#/components/schemas/ApiResponse")
+	}
+
+	cleanupOp := spec.Paths["/api/v1/monitor/job-logs/cleanup"]["post"]
+	assertJSONRequestRef(t, cleanupOp, "#/components/schemas/JobLogCleanupRequest")
+	if cleanupOp.RequestBody.Required {
+		t.Fatal("cleanup job logs request body should be optional")
+	}
+	assertSchemaMinimum(t, spec.Components.Schemas["JobLogCleanupRequest"].Properties["retention_days"], 1)
+	minimum := 1
+	assertQueryParameter(t, cleanupOp, "retention_days", Schema{Type: "integer", Format: "int64", Minimum: &minimum})
+
+	jobListOp := spec.Paths["/api/v1/monitor/jobs"]["get"]
+	assertSchemaIntegerEnum(t, queryParameter(t, jobListOp, "status").Schema, 0, 1)
+	jobHealthOp := spec.Paths["/api/v1/monitor/jobs/health"]["get"]
+	assertSchemaMinimum(t, queryParameter(t, jobHealthOp, "window_hours").Schema, 1)
 }
 
 func TestBuildSpecAddsTypedCoreSchemas(t *testing.T) {
@@ -132,6 +203,87 @@ func TestBuildSpecAddsTypedCoreSchemas(t *testing.T) {
 	assertJSONResponseRef(t, cleanupOp, "#/components/schemas/JobLogCleanupResultEnvelope")
 }
 
+func TestBuildSpecAddsHeartbeatAndServicesContracts(t *testing.T) {
+	spec := BuildSpec([]gin.RouteInfo{
+		{Method: "GET", Path: "/api/v1/monitor/jobs/heartbeats"},
+		{Method: "GET", Path: "/api/v1/monitor/services"},
+		{Method: "GET", Path: "/api/v1/monitor/mysql"},
+		{Method: "GET", Path: "/api/v1/monitor/jobs"},
+		{Method: "GET", Path: "/api/v1/monitor/jobs/health"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs"},
+		{Method: "PUT", Path: "/api/v1/monitor/jobs/:id"},
+		{Method: "DELETE", Path: "/api/v1/monitor/jobs/:id"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs/:id/start"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs/:id/stop"},
+		{Method: "POST", Path: "/api/v1/monitor/jobs/:id/run"},
+		{Method: "POST", Path: "/api/v1/monitor/job-logs/cleanup"},
+	}, Options{})
+
+	heartbeat := spec.Components.Schemas["JobHeartbeat"]
+	assertRequired(t, heartbeat.Required,
+		"id", "job_key", "service", "description", "interval_sec", "last_run_at",
+		"last_status", "last_error", "last_duration_ms", "runs", "fails", "updated_at", "stale",
+	)
+	assertPropertyType(t, heartbeat, "id", "integer")
+	assertPropertyType(t, heartbeat, "job_key", "string")
+	assertPropertyType(t, heartbeat, "interval_sec", "integer")
+	assertPropertyFormat(t, heartbeat, "last_run_at", "date-time")
+	assertPropertyType(t, heartbeat, "stale", "boolean")
+
+	heartbeatsResponse := spec.Components.Schemas["JobHeartbeatsResponse"]
+	assertRequired(t, heartbeatsResponse.Required, "list", "total")
+	assertPropertyType(t, heartbeatsResponse, "list", "array")
+	if heartbeatsResponse.Properties["list"].Items == nil || heartbeatsResponse.Properties["list"].Items.Ref != "#/components/schemas/JobHeartbeat" {
+		t.Fatalf("JobHeartbeatsResponse.list item ref = %#v, want JobHeartbeat", heartbeatsResponse.Properties["list"].Items)
+	}
+	assertPropertyType(t, heartbeatsResponse, "total", "integer")
+
+	servicesRow := spec.Components.Schemas["ServiceHealthRow"]
+	assertRequired(t, servicesRow.Required, "name", "ok", "http_code", "latency_ms")
+	assertNotRequired(t, servicesRow.Required, "error")
+	assertPropertyType(t, servicesRow, "name", "string")
+	assertPropertyType(t, servicesRow, "ok", "boolean")
+	assertPropertyType(t, servicesRow, "http_code", "integer")
+	assertPropertyType(t, servicesRow, "latency_ms", "integer")
+	assertPropertyType(t, servicesRow, "error", "string")
+
+	servicesResponse := spec.Components.Schemas["ServicesHealthResponse"]
+	assertRequired(t, servicesResponse.Required, "list", "total", "healthy", "checked_at")
+	assertPropertyType(t, servicesResponse, "list", "array")
+	if servicesResponse.Properties["list"].Items == nil || servicesResponse.Properties["list"].Items.Ref != "#/components/schemas/ServiceHealthRow" {
+		t.Fatalf("ServicesHealthResponse.list item ref = %#v, want ServiceHealthRow", servicesResponse.Properties["list"].Items)
+	}
+	assertPropertyType(t, servicesResponse, "total", "integer")
+	assertPropertyType(t, servicesResponse, "healthy", "integer")
+	assertPropertyFormat(t, servicesResponse, "checked_at", "date-time")
+
+	heartbeatsOp := spec.Paths["/api/v1/monitor/jobs/heartbeats"]["get"]
+	assertJSONResponseRef(t, heartbeatsOp, "#/components/schemas/JobHeartbeatsEnvelope")
+	assertJSONResponseRefAtStatus(t, heartbeatsOp, "503", "#/components/schemas/ApiResponse")
+
+	servicesOp := spec.Paths["/api/v1/monitor/services"]["get"]
+	assertJSONResponseRef(t, servicesOp, "#/components/schemas/ServicesHealthEnvelope")
+
+	for _, route := range []struct {
+		method string
+		path   string
+	}{
+		{method: "get", path: "/api/v1/monitor/mysql"},
+		{method: "get", path: "/api/v1/monitor/jobs"},
+		{method: "get", path: "/api/v1/monitor/jobs/health"},
+		{method: "post", path: "/api/v1/monitor/jobs"},
+		{method: "put", path: "/api/v1/monitor/jobs/{id}"},
+		{method: "delete", path: "/api/v1/monitor/jobs/{id}"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/start"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/stop"},
+		{method: "post", path: "/api/v1/monitor/jobs/{id}/run"},
+		{method: "post", path: "/api/v1/monitor/job-logs/cleanup"},
+	} {
+		op := spec.Paths[route.path][route.method]
+		assertJSONResponseRefAtStatus(t, op, "503", "#/components/schemas/ApiResponse")
+	}
+}
+
 func TestBuildSpecDocumentsPrometheusMetricsAsText(t *testing.T) {
 	spec := BuildSpec([]gin.RouteInfo{
 		{Method: "GET", Path: "/api/v1/metrics"},
@@ -163,6 +315,41 @@ func assertRequired(t *testing.T, got []string, want ...string) {
 	}
 }
 
+func assertNotRequired(t *testing.T, got []string, unwanted ...string) {
+	t.Helper()
+	values := make(map[string]struct{}, len(got))
+	for _, item := range got {
+		values[item] = struct{}{}
+	}
+	for _, item := range unwanted {
+		if _, ok := values[item]; ok {
+			t.Fatalf("required fields = %#v, did not want field %q", got, item)
+		}
+	}
+}
+
+func assertPropertyType(t *testing.T, schema Schema, name, want string) {
+	t.Helper()
+	property, ok := schema.Properties[name]
+	if !ok {
+		t.Fatalf("schema missing property %q", name)
+	}
+	if property.Type != want {
+		t.Fatalf("property %s type = %q, want %q", name, property.Type, want)
+	}
+}
+
+func assertPropertyFormat(t *testing.T, schema Schema, name, want string) {
+	t.Helper()
+	property, ok := schema.Properties[name]
+	if !ok {
+		t.Fatalf("schema missing property %q", name)
+	}
+	if property.Format != want {
+		t.Fatalf("property %s format = %q, want %q", name, property.Format, want)
+	}
+}
+
 func assertJSONRequestRef(t *testing.T, op Operation, want string) {
 	t.Helper()
 	if op.RequestBody == nil {
@@ -175,9 +362,73 @@ func assertJSONRequestRef(t *testing.T, op Operation, want string) {
 }
 
 func assertJSONResponseRef(t *testing.T, op Operation, want string) {
+	assertJSONResponseRefAtStatus(t, op, "200", want)
+}
+
+func assertJSONResponseRefAtStatus(t *testing.T, op Operation, status, want string) {
 	t.Helper()
-	got := op.Responses["200"].Content["application/json"].Schema.Ref
+	response, ok := op.Responses[status]
+	if !ok {
+		t.Fatalf("response %s is missing", status)
+	}
+	got := response.Content["application/json"].Schema.Ref
 	if got != want {
-		t.Fatalf("response schema ref = %q, want %q", got, want)
+		t.Fatalf("response %s schema ref = %q, want %q", status, got, want)
+	}
+}
+
+func queryParameter(t *testing.T, op Operation, name string) Parameter {
+	t.Helper()
+	for _, parameter := range op.Parameters {
+		if parameter.In == "query" && parameter.Name == name {
+			return parameter
+		}
+	}
+	t.Fatalf("query parameter %q is missing", name)
+	return Parameter{}
+}
+
+func assertQueryParameter(t *testing.T, op Operation, name string, want Schema) {
+	t.Helper()
+	got := queryParameter(t, op, name).Schema
+	if got.Type != want.Type || got.Format != want.Format {
+		t.Fatalf("query parameter %s schema = %#v, want type %q format %q", name, got, want.Type, want.Format)
+	}
+	if (got.Minimum == nil) != (want.Minimum == nil) || (got.Minimum != nil && *got.Minimum != *want.Minimum) {
+		t.Fatalf("query parameter %s minimum = %#v, want %#v", name, got.Minimum, want.Minimum)
+	}
+}
+
+func assertSchemaIntegerEnum(t *testing.T, schema Schema, want ...int) {
+	t.Helper()
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	var document struct {
+		Enum []int `json:"enum"`
+	}
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		t.Fatalf("unmarshal schema enum: %v", err)
+	}
+	if !reflect.DeepEqual(document.Enum, want) {
+		t.Fatalf("schema enum = %#v, want %#v", document.Enum, want)
+	}
+}
+
+func assertSchemaMinimum(t *testing.T, schema Schema, want int) {
+	t.Helper()
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	var document struct {
+		Minimum *int `json:"minimum"`
+	}
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		t.Fatalf("unmarshal schema minimum: %v", err)
+	}
+	if document.Minimum == nil || *document.Minimum != want {
+		t.Fatalf("schema minimum = %#v, want %d", document.Minimum, want)
 	}
 }

--- a/microservices/tests/openapi-contract.test.mjs
+++ b/microservices/tests/openapi-contract.test.mjs
@@ -18,18 +18,139 @@ test('monitor OpenAPI exposes health and monitor routes', async () => {
   assert.ok(spec.paths['/api/v1/monitor/redis']);
   assert.ok(spec.paths['/api/v1/monitor/jobs']);
   assert.ok(spec.paths['/api/v1/monitor/jobs/health']);
+  assert.ok(spec.paths['/api/v1/monitor/jobs/heartbeats']);
+  assert.ok(spec.paths['/api/v1/monitor/services']);
   assert.ok(spec.paths['/api/v1/monitor/jobs/{id}/run']);
   assert.ok(spec.paths['/api/v1/monitor/job-logs/cleanup']);
   assert.ok(spec.paths['/api/v1/metrics']);
-  assert.ok(Object.keys(spec.paths || {}).length >= 21);
 });
 
-test('optional web generated types file is schema-shaped when present', async () => {
-  let types;
-  try {
-    types = await readFile(new URL('../web/src/api/generated/schema.d.ts', import.meta.url), 'utf8');
-  } catch {
-    return;
+test('monitor OpenAPI exposes concrete heartbeat, services, and unavailable contracts', async () => {
+  const raw = await readFile(new URL('../services/monitor/docs/openapi.json', import.meta.url), 'utf8');
+  const spec = JSON.parse(raw);
+  const schemas = spec.components?.schemas;
+
+  assert.deepEqual(schemas.JobHeartbeatsResponse.required.sort(), ['list', 'total']);
+  assert.equal(schemas.JobHeartbeatsResponse.properties.list.type, 'array');
+  assert.equal(schemas.JobHeartbeatsResponse.properties.list.items.$ref, '#/components/schemas/JobHeartbeat');
+  assert.equal(schemas.JobHeartbeatsResponse.properties.total.type, 'integer');
+
+  assert.deepEqual(schemas.ServiceHealthRow.required.sort(), ['http_code', 'latency_ms', 'name', 'ok']);
+  assert.equal(schemas.ServiceHealthRow.properties.name.type, 'string');
+  assert.equal(schemas.ServiceHealthRow.properties.ok.type, 'boolean');
+  assert.equal(schemas.ServiceHealthRow.properties.http_code.type, 'integer');
+  assert.equal(schemas.ServiceHealthRow.properties.latency_ms.type, 'integer');
+  assert.equal(schemas.ServiceHealthRow.properties.error.type, 'string');
+  assert.equal(schemas.ServicesHealthResponse.properties.list.items.$ref, '#/components/schemas/ServiceHealthRow');
+  assert.equal(schemas.ServicesHealthResponse.properties.total.type, 'integer');
+  assert.equal(schemas.ServicesHealthResponse.properties.healthy.type, 'integer');
+  assert.equal(schemas.ServicesHealthResponse.properties.checked_at.format, 'date-time');
+
+  assert.equal(
+    schemas.JobHeartbeatsEnvelope.properties.data.$ref,
+    '#/components/schemas/JobHeartbeatsResponse',
+  );
+  assert.equal(
+    schemas.ServicesHealthEnvelope.properties.data.$ref,
+    '#/components/schemas/ServicesHealthResponse',
+  );
+
+  const heartbeatOperation = spec.paths['/api/v1/monitor/jobs/heartbeats'].get;
+  assert.equal(
+    heartbeatOperation.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/JobHeartbeatsEnvelope',
+  );
+  assert.equal(
+    heartbeatOperation.responses['503'].content['application/json'].schema.$ref,
+    '#/components/schemas/ApiResponse',
+  );
+  assert.equal(
+    spec.paths['/api/v1/monitor/services'].get.responses['200'].content['application/json'].schema.$ref,
+    '#/components/schemas/ServicesHealthEnvelope',
+  );
+  assert.equal(
+    spec.paths['/api/v1/monitor/mysql'].get.responses['503'].content['application/json'].schema.$ref,
+    '#/components/schemas/ApiResponse',
+  );
+});
+
+test('generated web types contain concrete monitor operations and schemas', async () => {
+  const types = await readFile(new URL('../web/src/api/generated/schema.d.ts', import.meta.url), 'utf8');
+
+  assert.match(types, /export interface paths/);
+  assert.match(types, /"\/api\/v1\/monitor\/jobs\/heartbeats": \{\s+get: operations\["getApiV1MonitorJobsHeartbeats"\];/);
+  assert.match(types, /"\/api\/v1\/monitor\/services": \{\s+get: operations\["getApiV1MonitorServices"\];/);
+  assert.match(types, /JobHeartbeat: \{[\s\S]*job_key: string;[\s\S]*stale: boolean;/);
+  assert.match(types, /ServiceHealthRow: \{[\s\S]*http_code: number;/);
+  assert.match(types, /ServiceHealthRow: \{[\s\S]*error\?: string;/);
+  assert.match(types, /JobHeartbeatsResponse: \{[\s\S]*list: components\["schemas"\]\["JobHeartbeat"\]\[\];[\s\S]*total: number;/);
+  assert.match(types, /ServicesHealthResponse: \{[\s\S]*healthy: number;/);
+  assert.match(types, /ServicesHealthResponse: \{[\s\S]*checked_at: string;/);
+
+  const cleanupStart = types.indexOf('  "postApiV1MonitorJobLogsCleanup": {');
+  assert.notEqual(cleanupStart, -1);
+  const cleanupOperation = types.slice(cleanupStart, types.indexOf('\n  };', cleanupStart));
+  assert.match(cleanupOperation, /requestBody\?: \{/);
+
+  const heartbeatStart = types.indexOf('  "getApiV1MonitorJobsHeartbeats": {');
+  assert.notEqual(heartbeatStart, -1);
+  const heartbeatOperation = types.slice(heartbeatStart, types.indexOf('\n  };', heartbeatStart));
+  assert.match(heartbeatOperation, /"200"[\s\S]*JobHeartbeatsEnvelope/);
+  assert.match(heartbeatOperation, /"503"[\s\S]*ApiResponse/);
+});
+
+test('monitor OpenAPI documents authorization, not-found, and validated job inputs', async () => {
+  const raw = await readFile(new URL('../services/monitor/docs/openapi.json', import.meta.url), 'utf8');
+  const spec = JSON.parse(raw);
+  const apiResponse = spec.components.schemas.ApiResponse;
+
+  assert.deepEqual(apiResponse.required.sort(), ['code', 'message']);
+
+  for (const [path, method] of [
+    ['/api/v1/monitor/server', 'get'],
+    ['/api/v1/monitor/services', 'get'],
+    ['/api/v1/monitor/mysql', 'get'],
+    ['/api/v1/monitor/redis', 'get'],
+    ['/api/v1/monitor/jobs', 'get'],
+    ['/api/v1/monitor/jobs', 'post'],
+    ['/api/v1/monitor/jobs/health', 'get'],
+    ['/api/v1/monitor/jobs/heartbeats', 'get'],
+    ['/api/v1/monitor/jobs/{id}', 'put'],
+    ['/api/v1/monitor/jobs/{id}', 'delete'],
+    ['/api/v1/monitor/jobs/{id}/start', 'post'],
+    ['/api/v1/monitor/jobs/{id}/stop', 'post'],
+    ['/api/v1/monitor/jobs/{id}/run', 'post'],
+    ['/api/v1/monitor/job-logs/cleanup', 'post'],
+  ]) {
+    assert.equal(
+      spec.paths[path][method].responses['403'].content['application/json'].schema.$ref,
+      '#/components/schemas/ApiResponse',
+    );
   }
-  assert.ok(types.includes('export interface paths') || types.includes('paths'));
+
+  for (const [path, method] of [
+    ['/api/v1/monitor/jobs/{id}', 'put'],
+    ['/api/v1/monitor/jobs/{id}', 'delete'],
+    ['/api/v1/monitor/jobs/{id}/start', 'post'],
+    ['/api/v1/monitor/jobs/{id}/stop', 'post'],
+    ['/api/v1/monitor/jobs/{id}/run', 'post'],
+  ]) {
+    assert.equal(
+      spec.paths[path][method].responses['404'].content['application/json'].schema.$ref,
+      '#/components/schemas/ApiResponse',
+    );
+  }
+
+  const cleanup = spec.paths['/api/v1/monitor/job-logs/cleanup'].post;
+  assert.equal(cleanup.requestBody.required, false);
+  assert.deepEqual(
+    cleanup.parameters.find((parameter) => parameter.in === 'query' && parameter.name === 'retention_days').schema,
+    { type: 'integer', format: 'int64', minimum: 1 },
+  );
+  assert.equal(spec.components.schemas.JobLogCleanupRequest.properties.retention_days.minimum, 1);
+
+  const jobList = spec.paths['/api/v1/monitor/jobs'].get;
+  assert.deepEqual(jobList.parameters.find((parameter) => parameter.in === 'query' && parameter.name === 'status').schema.enum, [0, 1]);
+  const jobHealth = spec.paths['/api/v1/monitor/jobs/health'].get;
+  assert.equal(jobHealth.parameters.find((parameter) => parameter.in === 'query' && parameter.name === 'window_hours').schema.minimum, 1);
 });

--- a/microservices/web/e2e/auth-refresh-lock-regression.spec.ts
+++ b/microservices/web/e2e/auth-refresh-lock-regression.spec.ts
@@ -1,0 +1,624 @@
+import { test, expect, type BrowserContext, type Page, type Route } from '@playwright/test'
+import { STORAGE_STATE } from './global-setup'
+
+const AUTH_REFRESH_LOCK_KEY = 'go-admin-kit-auth-refresh-lock'
+const AUTH_TOKEN_PAIR_KEY = 'auth_token_pair'
+const USER_ME_PATH = '/api/v1/user/me'
+
+const userMeSuccess = {
+  id: 1,
+  username: 'refresh-lock-admin',
+  nickname: '刷新锁测试用户',
+  roles: [{ id: 1, name: '超级管理员', code: 'super_admin' }],
+  permissions: [],
+}
+
+test.use({ storageState: STORAGE_STATE })
+
+test.beforeEach(async ({ page }) => {
+  await page.context().addInitScript(() => {
+    try {
+      localStorage.removeItem('auth_token_pair')
+      localStorage.setItem('access_token', 'fixture-access')
+      localStorage.setItem('refresh_token', 'fixture-refresh')
+    } catch {
+      // The initial about:blank document may not have a storage origin yet.
+    }
+  })
+})
+
+type IndexedDBFailure = 'error' | 'abort' | 'blocked' | 'closed'
+
+const unauthorized = async (route: Route) => {
+  await route.fulfill({
+    status: 401,
+    contentType: 'application/json',
+    body: JSON.stringify({ code: 401, message: 'access token expired' }),
+  })
+}
+
+function waitForUserMeSuccess(page: Page, accessToken: string) {
+  return page.waitForResponse(
+    (response) => (
+      new URL(response.url()).pathname === USER_ME_PATH &&
+      response.status() === 200 &&
+      response.request().headers().authorization === `Bearer ${accessToken}`
+    ),
+    { timeout: 8_000 },
+  )
+}
+
+async function assertUserMeSuccess(response: Awaited<ReturnType<typeof waitForUserMeSuccess>>, accessToken: string) {
+  expect(response.status()).toBe(200)
+  expect(response.request().headers().authorization).toBe(`Bearer ${accessToken}`)
+  await expect(response.json()).resolves.toMatchObject({
+    code: 200,
+    data: { username: userMeSuccess.username },
+  })
+}
+
+function expectTokenPair(page: Page, access: string, refresh: string) {
+  return expect
+    .poll(() => page.evaluate((pairKey) => {
+      let pair: unknown = null
+      try {
+        pair = JSON.parse(localStorage.getItem(pairKey) || 'null')
+      } catch {
+        pair = null
+      }
+      return {
+        access: localStorage.getItem('access_token'),
+        refresh: localStorage.getItem('refresh_token'),
+        pair,
+      }
+    }, AUTH_TOKEN_PAIR_KEY))
+    .toEqual({ access, refresh, pair: { access, refresh } })
+}
+
+async function installIndexedDBFailure(context: BrowserContext, failure: IndexedDBFailure) {
+  await context.addInitScript((mode: IndexedDBFailure) => {
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: undefined,
+    })
+
+    const createOpenRequest = () => {
+      const request = {
+        result: undefined as unknown,
+        onupgradeneeded: null as ((event: Event) => void) | null,
+        onsuccess: null as ((event: Event) => void) | null,
+        onerror: null as ((event: Event) => void) | null,
+        onblocked: null as ((event: Event) => void) | null,
+      }
+      window.setTimeout(() => {
+        if (mode === 'blocked') request.onblocked?.(new Event('blocked'))
+        else if (mode === 'error') request.onerror?.(new Event('error'))
+      }, 0)
+      return request
+    }
+
+    const state = window as Window & { indexedDBTransactionCalls?: number }
+    state.indexedDBTransactionCalls = 0
+    const database = {
+      objectStoreNames: { contains: () => true },
+      close: () => undefined,
+      transaction: () => {
+        state.indexedDBTransactionCalls = (state.indexedDBTransactionCalls || 0) + 1
+        if (mode === 'closed') {
+          throw new DOMException('The database connection is closing.', 'InvalidStateError')
+        }
+
+        const transaction = {
+          oncomplete: null as (() => void) | null,
+          onerror: null as (() => void) | null,
+          onabort: null as (() => void) | null,
+          objectStore: () => ({
+            get: () => {
+              const request = {
+                result: undefined as unknown,
+                onsuccess: null as ((event: Event) => void) | null,
+              }
+              window.setTimeout(() => request.onsuccess?.(new Event('success')), 0)
+              return request
+            },
+            put: () => undefined,
+            delete: () => undefined,
+          }),
+        }
+
+        if (mode === 'abort') {
+          window.setTimeout(() => transaction.onabort?.(), 0)
+        }
+        return transaction
+      },
+    }
+
+    Object.defineProperty(window, 'indexedDB', {
+      configurable: true,
+      value: {
+        open: () => {
+          if (mode !== 'abort' && mode !== 'closed') return createOpenRequest()
+          const request = createOpenRequest()
+          request.result = database
+          window.setTimeout(() => request.onsuccess?.(new Event('success')), 0)
+          return request
+        },
+      },
+    })
+  }, failure)
+}
+
+async function installTransientIndexedDBFailure(context: BrowserContext) {
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: undefined,
+    })
+
+    const nativeIndexedDB = window.indexedDB
+    let failNextOpen = true
+    Object.defineProperty(window, 'indexedDB', {
+      configurable: true,
+      value: {
+        open: (name: string, version?: number) => {
+          if (failNextOpen) {
+            failNextOpen = false
+            throw new DOMException('IndexedDB is temporarily unavailable', 'InvalidStateError')
+          }
+          return nativeIndexedDB.open(name, version)
+        },
+      },
+    })
+    const controls = window as Window & { allowRefreshIndexedDB?: () => void }
+    controls.allowRefreshIndexedDB = () => {
+      failNextOpen = false
+    }
+  })
+}
+
+async function installRejectingWebLocks(context: BrowserContext) {
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: () => Promise.reject(new Error('Web Locks API rejected')),
+      },
+    })
+  })
+}
+
+async function installImmediateWebLockNearDeadline(context: BrowserContext) {
+  await context.addInitScript(() => {
+    const realNow = Date.now
+    let elapsed = 0
+    Object.defineProperty(Date, 'now', {
+      configurable: true,
+      value: () => realNow() + elapsed,
+    })
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: async (_name: string, _options: unknown, callback: (lock: object) => Promise<unknown>) => {
+          elapsed = 19_700
+          return callback({})
+        },
+      },
+    })
+  })
+}
+
+test.describe('authentication refresh lock regressions', () => {
+  for (const failure of ['error', 'abort', 'blocked', 'closed'] as const) {
+    test(`does not fall back to localStorage after IndexedDB ${failure}`, async ({ page }) => {
+      await installIndexedDBFailure(page.context(), failure)
+      let refreshCalls = 0
+
+      await page.route('**/api/v1/user/me', unauthorized)
+      await page.route('**/api/v1/refresh', async (route) => {
+        refreshCalls += 1
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 200,
+            data: { access_token: 'test-access-placeholder', refresh_token: 'test-refresh-placeholder' },
+          }),
+        })
+      })
+
+      await page.goto('/system/user')
+      await page.waitForTimeout(1_200)
+
+      expect(refreshCalls).toBe(0)
+      await expect(page.evaluate((key) => localStorage.getItem(key), AUTH_REFRESH_LOCK_KEY)).resolves.toBeNull()
+      if (failure === 'abort' || failure === 'closed') {
+        await expect(page.evaluate(() => (window as Window & { indexedDBTransactionCalls?: number }).indexedDBTransactionCalls))
+          .resolves.toBeGreaterThan(0)
+      }
+    })
+  }
+
+  test('falls back to IndexedDB coordination when Web Locks API rejects', async ({ page }) => {
+    const context = page.context()
+    await installRejectingWebLocks(context)
+    const peer = await context.newPage()
+    let refreshCalls = 0
+
+    await context.route('**/api/v1/user/me', async (route) => {
+      if (route.request().headers().authorization === 'Bearer test-locks-access') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: userMeSuccess }),
+        })
+        return
+      }
+      await unauthorized(route)
+    })
+    await context.route('**/api/v1/refresh', async (route) => {
+      refreshCalls += 1
+      if (refreshCalls > 1) {
+        await unauthorized(route)
+        return
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          data: { access_token: 'test-locks-access', refresh_token: 'test-locks-refresh' },
+        }),
+      })
+    })
+
+    try {
+      const pageSuccess = waitForUserMeSuccess(page, 'test-locks-access')
+      const peerSuccess = waitForUserMeSuccess(peer, 'test-locks-access')
+      await Promise.all([page.goto('/system/user'), peer.goto('/system/user')])
+      await assertUserMeSuccess(await pageSuccess, 'test-locks-access')
+      await assertUserMeSuccess(await peerSuccess, 'test-locks-access')
+      await expect.poll(() => refreshCalls, { timeout: 5_000 }).toBe(1)
+      await expect
+        .poll(() => page.evaluate(() => localStorage.getItem('refresh_token')), { timeout: 5_000 })
+        .toBe('test-locks-refresh')
+      await expect(page).not.toHaveURL(/\/login/)
+      await expect(peer).not.toHaveURL(/\/login/)
+      await expect
+        .poll(() => page.evaluate((pairKey) => localStorage.getItem(pairKey), AUTH_TOKEN_PAIR_KEY))
+        .toBe(JSON.stringify({ access: 'test-locks-access', refresh: 'test-locks-refresh' }))
+    } finally {
+      await peer.close()
+    }
+  })
+
+  test('retries IndexedDB after a transient open failure without using localStorage', async ({ page }) => {
+    await installTransientIndexedDBFailure(page.context())
+    let refreshCalls = 0
+
+    await page.route('**/api/v1/user/me', async (route) => {
+      if (route.request().headers().authorization === 'Bearer test-transient-access') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: userMeSuccess }),
+        })
+        return
+      }
+      await unauthorized(route)
+    })
+    await page.route('**/api/v1/refresh', async (route) => {
+      refreshCalls += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          message: 'ok',
+          data: { access_token: 'test-transient-access', refresh_token: 'test-transient-refresh' },
+        }),
+      })
+    })
+
+    const success = waitForUserMeSuccess(page, 'test-transient-access')
+    await page.goto('/system/user', { waitUntil: 'domcontentloaded' })
+    await page.evaluate(() => {
+      const controls = window as Window & { allowRefreshIndexedDB?: () => void }
+      controls.allowRefreshIndexedDB?.()
+    })
+
+    await assertUserMeSuccess(await success, 'test-transient-access')
+    expect(refreshCalls).toBe(1)
+    await expect(page).not.toHaveURL(/\/login/)
+  })
+
+  test('new reader migrates a token pair written by an older page', async ({ page }) => {
+    await page.context().addInitScript(() => {
+      localStorage.setItem('auth_token_pair', JSON.stringify({ access: 'test-stale-access', refresh: 'test-stale-refresh' }))
+      localStorage.setItem('access_token', 'test-legacy-access')
+      localStorage.setItem('refresh_token', 'test-legacy-refresh')
+    })
+    await page.route('**/api/v1/user/me', async (route) => {
+      if (route.request().headers().authorization === 'Bearer test-legacy-access') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: userMeSuccess }),
+        })
+        return
+      }
+      await unauthorized(route)
+    })
+    await page.route('**/api/v1/user/menus', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 200, message: 'ok', data: [] }),
+      })
+    })
+
+    const success = waitForUserMeSuccess(page, 'test-legacy-access')
+    await page.goto('/system/user')
+    await assertUserMeSuccess(await success, 'test-legacy-access')
+    await expectTokenPair(page, 'test-legacy-access', 'test-legacy-refresh')
+    await expect(page).not.toHaveURL(/\/login/)
+  })
+
+  test('new reader accepts an older page login after the pair was cleared', async ({ page }) => {
+    await page.context().addInitScript(() => {
+      localStorage.setItem('auth_token_pair', JSON.stringify({ access: '', refresh: '' }))
+      localStorage.setItem('access_token', 'test-legacy-login-access')
+      localStorage.setItem('refresh_token', 'test-legacy-login-refresh')
+    })
+    await page.route('**/api/v1/user/me', async (route) => {
+      if (route.request().headers().authorization === 'Bearer test-legacy-login-access') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: userMeSuccess }),
+        })
+        return
+      }
+      await unauthorized(route)
+    })
+    await page.route('**/api/v1/user/menus', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 200, message: 'ok', data: [] }),
+      })
+    })
+
+    const success = waitForUserMeSuccess(page, 'test-legacy-login-access')
+    await page.goto('/system/user')
+    await assertUserMeSuccess(await success, 'test-legacy-login-access')
+    await expectTokenPair(page, 'test-legacy-login-access', 'test-legacy-login-refresh')
+    await expect(page).not.toHaveURL(/\/login/)
+  })
+
+  test('does not treat a refresh callback failure as a Web Locks API failure', async ({ page }) => {
+    const context = page.context()
+    await context.addInitScript(() => {
+      Object.defineProperty(navigator, 'locks', {
+        configurable: true,
+        value: {
+          request: async (_name: string, _options: unknown, callback: (lock: object) => Promise<unknown>) =>
+            callback({}),
+        },
+      })
+    })
+    let refreshCalls = 0
+
+    await page.route('**/api/v1/user/me', unauthorized)
+    await page.route('**/api/v1/refresh', async (route) => {
+      refreshCalls += 1
+      if (refreshCalls === 1) {
+        await unauthorized(route)
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          data: { access_token: 'test-fallback-access', refresh_token: 'test-fallback-refresh' },
+        }),
+      })
+    })
+
+    await page.goto('/system/user')
+    await expect(page).toHaveURL(/\/login/, { timeout: 5_000 })
+    await page.waitForTimeout(300)
+    expect(refreshCalls).toBe(1)
+  })
+
+  test('bounds an acquired lock refresh request by the shared 20 second deadline', async ({ page }) => {
+    await installImmediateWebLockNearDeadline(page.context())
+    await page.route('**/api/v1/user/me', unauthorized)
+    await page.route('**/api/v1/refresh', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60_000))
+    })
+
+    await page.goto('/system/user')
+    await expect(page).toHaveURL(/\/login/, { timeout: 3_000 })
+  })
+
+  test('bounds a never-settling Web Locks request by the shared 20 second deadline', async ({ page }) => {
+    await page.context().addInitScript(() => {
+      const realNow = Date.now
+      let elapsed = 0
+      Object.defineProperty(Date, 'now', {
+        configurable: true,
+        value: () => realNow() + elapsed,
+      })
+      Object.defineProperty(navigator, 'locks', {
+        configurable: true,
+        value: {
+          request: () => {
+            elapsed = 19_700
+            return new Promise<never>(() => {})
+          },
+        },
+      })
+    })
+    await page.route('**/api/v1/user/me', unauthorized)
+
+    await page.goto('/system/user')
+    await expect(page).toHaveURL(/\/login/, { timeout: 3_000 })
+  })
+
+  test('bounds a never-settling IndexedDB open by the shared 20 second deadline', async ({ page }) => {
+    await page.context().addInitScript(() => {
+      const realNow = Date.now
+      let elapsed = 0
+      Object.defineProperty(Date, 'now', {
+        configurable: true,
+        value: () => realNow() + elapsed,
+      })
+      Object.defineProperty(navigator, 'locks', {
+        configurable: true,
+        value: undefined,
+      })
+      Object.defineProperty(window, 'indexedDB', {
+        configurable: true,
+        value: {
+          open: () => {
+            elapsed = 19_700
+            return {}
+          },
+        },
+      })
+    })
+    await page.route('**/api/v1/user/me', unauthorized)
+
+    await page.goto('/system/user')
+    await expect(page).toHaveURL(/\/login/, { timeout: 3_000 })
+  })
+
+  test('bounds a never-settling IndexedDB transaction by the shared 20 second deadline', async ({ page }) => {
+    await page.context().addInitScript(() => {
+      const realNow = Date.now
+      let elapsed = 0
+      Object.defineProperty(Date, 'now', {
+        configurable: true,
+        value: () => realNow() + elapsed,
+      })
+      Object.defineProperty(navigator, 'locks', {
+        configurable: true,
+        value: undefined,
+      })
+      const database = {
+        objectStoreNames: { contains: () => true },
+        close: () => undefined,
+        transaction: () => {
+          elapsed = 19_700
+          return {
+            oncomplete: null as (() => void) | null,
+            onerror: null as (() => void) | null,
+            onabort: null as (() => void) | null,
+            objectStore: () => ({
+              get: () => ({
+                result: undefined,
+                onsuccess: null as ((event: Event) => void) | null,
+                onerror: null as ((event: Event) => void) | null,
+              }),
+              put: () => undefined,
+              delete: () => undefined,
+            }),
+          }
+        },
+      }
+      Object.defineProperty(window, 'indexedDB', {
+        configurable: true,
+        value: {
+          open: () => {
+            const request = {
+              result: database,
+              onupgradeneeded: null as ((event: Event) => void) | null,
+              onsuccess: null as ((event: Event) => void) | null,
+              onerror: null as ((event: Event) => void) | null,
+              onblocked: null as ((event: Event) => void) | null,
+            }
+            window.setTimeout(() => request.onsuccess?.(new Event('success')), 0)
+            return request
+          },
+        },
+      })
+    })
+    await page.route('**/api/v1/user/me', unauthorized)
+
+    await page.goto('/system/user')
+    await expect(page).toHaveURL(/\/login/, { timeout: 3_000 })
+  })
+
+  test('bounds 401 recovery waiting by the same deadline', async ({ page }) => {
+    await installImmediateWebLockNearDeadline(page.context())
+    let refreshCalls = 0
+
+    await page.route('**/api/v1/user/me', unauthorized)
+    await page.route('**/api/v1/refresh', async (route) => {
+      refreshCalls += 1
+      await unauthorized(route)
+    })
+
+    await page.goto('/system/user')
+    await expect.poll(() => refreshCalls, { timeout: 2_000 }).toBe(1)
+    await expect(page).toHaveURL(/\/login/, { timeout: 1_500 })
+  })
+
+  test('reuses one refresh promise and one token pair for same-page 401s', async ({ page }) => {
+    let refreshCalls = 0
+    await page.route('**/api/v1/user/me', async (route) => {
+      if (route.request().headers().authorization === 'Bearer test-same-page-access') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: userMeSuccess }),
+        })
+        return
+      }
+      await unauthorized(route)
+    })
+    await page.route('**/api/v1/user/menus', async (route) => {
+      if (route.request().headers().authorization === 'Bearer test-same-page-access') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: [] }),
+        })
+        return
+      }
+      await unauthorized(route)
+    })
+    await page.route('**/api/v1/refresh', async (route) => {
+      refreshCalls += 1
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 200,
+          data: { access_token: 'test-same-page-access', refresh_token: 'test-same-page-refresh' },
+        }),
+      })
+    })
+
+    const userMeSuccessResponse = waitForUserMeSuccess(page, 'test-same-page-access')
+    const menusSuccessResponse = page.waitForResponse(
+      (response) => (
+        new URL(response.url()).pathname === '/api/v1/user/menus' &&
+        response.status() === 200 &&
+        response.request().headers().authorization === 'Bearer test-same-page-access'
+      ),
+      { timeout: 8_000 },
+    )
+    await page.goto('/system/user')
+    await assertUserMeSuccess(await userMeSuccessResponse, 'test-same-page-access')
+    const menusResponse = await menusSuccessResponse
+    expect(menusResponse.status()).toBe(200)
+    expect(menusResponse.request().headers().authorization).toBe('Bearer test-same-page-access')
+    await expect(menusResponse.json()).resolves.toMatchObject({ code: 200, data: [] })
+    await expect.poll(() => refreshCalls, { timeout: 5_000 }).toBe(1)
+    await expectTokenPair(page, 'test-same-page-access', 'test-same-page-refresh')
+  })
+})

--- a/microservices/web/e2e/auth-refresh.spec.ts
+++ b/microservices/web/e2e/auth-refresh.spec.ts
@@ -1,25 +1,106 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type BrowserContext, type Page } from '@playwright/test'
 import { STORAGE_STATE } from './global-setup'
 
 test.use({ storageState: STORAGE_STATE })
 
-test.describe('登录态刷新', () => {
-  test('两个页面同时失效时只刷新一次且不跳转登录', async ({ page }) => {
-    const context = page.context()
-    const peer = await context.newPage()
-    let refreshCalls = 0
+const OLD_ACCESS_TOKEN = 'test-old-access'
+const OLD_REFRESH_TOKEN = 'test-old-refresh'
+const NEW_ACCESS_TOKEN = 'test-new-access'
+const NEW_REFRESH_TOKEN = 'test-new-refresh'
+const AUTH_TOKEN_PAIR_KEY = 'auth_token_pair'
+const USER_ME_PATH = '/api/v1/user/me'
+const REFRESH_PATH = '/api/v1/refresh'
 
-    await context.route('**/api/v1/user/me', async (route) => {
+type UserMeAttempt = {
+  authorization: string | undefined
+  status: number
+}
+
+type RefreshFixture = {
+  userMeAttempts: UserMeAttempt[]
+  refreshCalls: number
+}
+
+const userMeSuccess = {
+  id: 1,
+  username: 'refresh-admin',
+  nickname: '刷新测试用户',
+  roles: [{ id: 1, name: '超级管理员', code: 'super_admin' }],
+  permissions: [],
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function installRefreshFixture(
+  context: BrowserContext,
+  options: { disableWebLocks?: boolean; refreshBehavior?: 'rotate' | 'timeout' } = {},
+): Promise<RefreshFixture> {
+  if (options.disableWebLocks) {
+    await context.addInitScript(() => {
+      Object.defineProperty(navigator, 'locks', {
+        configurable: true,
+        value: undefined,
+      })
+    })
+  }
+
+  await context.addInitScript(({ access, refresh }) => {
+    localStorage.removeItem('auth_token_pair')
+    localStorage.setItem('access_token', access)
+    localStorage.setItem('refresh_token', refresh)
+  }, { access: OLD_ACCESS_TOKEN, refresh: OLD_REFRESH_TOKEN })
+
+  const fixture: RefreshFixture = {
+    userMeAttempts: [],
+    refreshCalls: 0,
+  }
+
+  await context.route('**/api/v1/**', async (route) => {
+    const pathname = new URL(route.request().url()).pathname
+
+    if (pathname === USER_ME_PATH) {
+      const authorization = route.request().headers().authorization
+      if (authorization === `Bearer ${OLD_ACCESS_TOKEN}`) {
+        fixture.userMeAttempts.push({ authorization, status: 401 })
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 401, message: 'access token expired' }),
+        })
+        return
+      }
+
+      if (authorization === `Bearer ${NEW_ACCESS_TOKEN}`) {
+        fixture.userMeAttempts.push({ authorization, status: 200 })
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 200, message: 'ok', data: userMeSuccess }),
+        })
+        return
+      }
+
+      fixture.userMeAttempts.push({ authorization, status: 401 })
       await route.fulfill({
         status: 401,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 401, message: 'access token expired' }),
+        body: JSON.stringify({ code: 401, message: 'unexpected access token' }),
       })
-    })
+      return
+    }
 
-    await context.route('**/api/v1/refresh', async (route) => {
-      refreshCalls += 1
-      if (refreshCalls > 1) {
+    if (pathname === REFRESH_PATH) {
+      fixture.refreshCalls += 1
+      if (options.refreshBehavior === 'timeout') {
+        // Leave the request pending long enough for Axios' 15 second timeout
+        // to fire; this exercises the client timeout path rather than a
+        // synthetic route abort.
+        await wait(16_000)
+        await route.abort('timedout')
+        return
+      }
+
+      if (fixture.refreshCalls > 1) {
         await route.fulfill({
           status: 401,
           contentType: 'application/json',
@@ -28,8 +109,7 @@ test.describe('登录态刷新', () => {
         return
       }
 
-      // 模拟后端 rotation：第一个请求完成前，后续请求也不能复用旧 token。
-      await new Promise((resolve) => setTimeout(resolve, 250))
+      await wait(250)
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -37,70 +117,143 @@ test.describe('登录态刷新', () => {
           code: 200,
           message: 'ok',
           data: {
-            access_token: 'access-fixture',
-            refresh_token: 'refresh-fixture',
+            access_token: NEW_ACCESS_TOKEN,
+            refresh_token: NEW_REFRESH_TOKEN,
           },
         }),
       })
+      return
+    }
+
+    const data = pathname === '/api/v1/user/menus'
+      ? []
+      : { list: [], total: 0, page: 1, page_size: 10 }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 200, message: 'ok', data }),
     })
+  })
+
+  return fixture
+}
+
+function waitForUserMeResponse(page: Page, status: number) {
+  return page.waitForResponse(
+    (response) => new URL(response.url()).pathname === USER_ME_PATH && response.status() === status,
+    { timeout: 8_000 },
+  )
+}
+
+async function assertUserMeResponse(
+  response: {
+    status(): number
+    request(): { headers(): Record<string, string> }
+    json(): Promise<unknown>
+  },
+  expectedStatus: number,
+  expectedAuthorization: string,
+) {
+  expect(response.status()).toBe(expectedStatus)
+  expect(response.request().headers().authorization).toBe(expectedAuthorization)
+  if (expectedStatus === 200) {
+    await expect(response.json()).resolves.toMatchObject({
+      code: 200,
+      data: { username: userMeSuccess.username },
+    })
+  }
+}
+
+function assertRotatedUserMeAttempts(fixture: RefreshFixture, expectedSuccesses: number) {
+  const oldTokenFailures = fixture.userMeAttempts.filter((attempt) => (
+    attempt.authorization === `Bearer ${OLD_ACCESS_TOKEN}` && attempt.status === 401
+  ))
+  const newTokenSuccesses = fixture.userMeAttempts.filter((attempt) => (
+    attempt.authorization === `Bearer ${NEW_ACCESS_TOKEN}` && attempt.status === 200
+  ))
+
+  expect(oldTokenFailures.length).toBeGreaterThanOrEqual(expectedSuccesses)
+  expect(newTokenSuccesses.length).toBe(oldTokenFailures.length)
+  expect(fixture.userMeAttempts).toHaveLength(oldTokenFailures.length + newTokenSuccesses.length)
+}
+
+function expectTokenPair(page: Page, access: string, refresh: string) {
+  return expect
+    .poll(() => page.evaluate((pairKey) => {
+      let pair: unknown = null
+      try {
+        pair = JSON.parse(localStorage.getItem(pairKey) || 'null')
+      } catch {
+        pair = null
+      }
+      return {
+        access: localStorage.getItem('access_token'),
+        refresh: localStorage.getItem('refresh_token'),
+        pair,
+      }
+    }, AUTH_TOKEN_PAIR_KEY))
+    .toEqual({ access, refresh, pair: { access, refresh } })
+}
+
+test.describe('登录态刷新', () => {
+  test('两个页面同时失效时只刷新一次，并用新 token 重试 user/me 成功', async ({ page }) => {
+    const context = page.context()
+    const fixture = await installRefreshFixture(context)
+    const peer = await context.newPage()
 
     try {
-      await Promise.all([page.goto('/system/user'), peer.goto('/system/user')])
+      const pageExpiredUserMe = waitForUserMeResponse(page, 401)
+      const peerExpiredUserMe = waitForUserMeResponse(peer, 401)
+      const pageSuccessfulUserMe = waitForUserMeResponse(page, 200)
+      const peerSuccessfulUserMe = waitForUserMeResponse(peer, 200)
+      await Promise.all([page.goto('/403'), peer.goto('/403')])
 
-      await expect
-        .poll(() => refreshCalls, { timeout: 5_000 })
-        .toBe(1)
-      await expect
-        .poll(() => page.evaluate(() => localStorage.getItem('refresh_token')), {
-          timeout: 5_000,
-        })
-        .toBe('refresh-fixture')
-      await expect(page).not.toHaveURL(/\/login/)
-      await expect(peer).not.toHaveURL(/\/login/)
+      const [pageExpiredResponse, peerExpiredResponse, pageResponse, peerResponse] = await Promise.all([
+        pageExpiredUserMe,
+        peerExpiredUserMe,
+        pageSuccessfulUserMe,
+        peerSuccessfulUserMe,
+      ])
+      await assertUserMeResponse(pageExpiredResponse, 401, `Bearer ${OLD_ACCESS_TOKEN}`)
+      await assertUserMeResponse(peerExpiredResponse, 401, `Bearer ${OLD_ACCESS_TOKEN}`)
+      await assertUserMeResponse(pageResponse, 200, `Bearer ${NEW_ACCESS_TOKEN}`)
+      await assertUserMeResponse(peerResponse, 200, `Bearer ${NEW_ACCESS_TOKEN}`)
+
+      expect(fixture.refreshCalls).toBe(1)
+      assertRotatedUserMeAttempts(fixture, 1)
+      await expectTokenPair(page, NEW_ACCESS_TOKEN, NEW_REFRESH_TOKEN)
+      await expectTokenPair(peer, NEW_ACCESS_TOKEN, NEW_REFRESH_TOKEN)
     } finally {
       await peer.close()
     }
   })
 
-  test('无 Web Locks 时使用 IndexedDB 租约协调刷新', async ({ page }) => {
+  test('无 Web Locks 时使用 IndexedDB 租约协调刷新，并用新 token 重试 user/me 成功', async ({ page }) => {
     const context = page.context()
-    await context.addInitScript(() => {
-      Object.defineProperty(navigator, 'locks', {
-        configurable: true,
-        value: undefined,
-      })
-    })
+    const fixture = await installRefreshFixture(context, { disableWebLocks: true })
     const peer = await context.newPage()
-    let refreshCalls = 0
-
-    await context.route('**/api/v1/user/me', async (route) => {
-      await route.fulfill({
-        status: 401,
-        contentType: 'application/json',
-        body: JSON.stringify({ code: 401, message: 'access token expired' }),
-      })
-    })
-
-    await context.route('**/api/v1/refresh', async (route) => {
-      refreshCalls += 1
-      await new Promise((resolve) => setTimeout(resolve, 250))
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          code: 200,
-          message: 'ok',
-          data: {
-            access_token: 'test-indexeddb-access',
-            refresh_token: 'test-indexeddb-refresh',
-          },
-        }),
-      })
-    })
 
     try {
-      await Promise.all([page.goto('/system/user'), peer.goto('/system/user')])
-      await expect.poll(() => refreshCalls, { timeout: 5_000 }).toBe(1)
+      const pageExpiredUserMe = waitForUserMeResponse(page, 401)
+      const peerExpiredUserMe = waitForUserMeResponse(peer, 401)
+      const pageSuccessfulUserMe = waitForUserMeResponse(page, 200)
+      const peerSuccessfulUserMe = waitForUserMeResponse(peer, 200)
+      await Promise.all([page.goto('/403'), peer.goto('/403')])
+
+      const [pageExpiredResponse, peerExpiredResponse, pageResponse, peerResponse] = await Promise.all([
+        pageExpiredUserMe,
+        peerExpiredUserMe,
+        pageSuccessfulUserMe,
+        peerSuccessfulUserMe,
+      ])
+      await expect.poll(() => page.evaluate(() => navigator.locks === undefined)).toBe(true)
+      await assertUserMeResponse(pageExpiredResponse, 401, `Bearer ${OLD_ACCESS_TOKEN}`)
+      await assertUserMeResponse(peerExpiredResponse, 401, `Bearer ${OLD_ACCESS_TOKEN}`)
+      await assertUserMeResponse(pageResponse, 200, `Bearer ${NEW_ACCESS_TOKEN}`)
+      await assertUserMeResponse(peerResponse, 200, `Bearer ${NEW_ACCESS_TOKEN}`)
+
+      expect(fixture.refreshCalls).toBe(1)
+      assertRotatedUserMeAttempts(fixture, 1)
       await expect
         .poll(
           () =>
@@ -111,26 +264,50 @@ test.describe('登录态刷新', () => {
           { timeout: 5_000 },
         )
         .toBe(true)
-      await expect(page).not.toHaveURL(/\/login/)
-      await expect(peer).not.toHaveURL(/\/login/)
+      await expectTokenPair(page, NEW_ACCESS_TOKEN, NEW_REFRESH_TOKEN)
+      await expectTokenPair(peer, NEW_ACCESS_TOKEN, NEW_REFRESH_TOKEN)
     } finally {
       await peer.close()
     }
   })
 
-  test('refresh 请求卡住时最终跳转登录而不是无限等待', async ({ page }) => {
-    await page.route('**/api/v1/user/me', async (route) => {
+  test('refresh 请求卡住时在有限时间内最终跳转登录，而不是无限等待', async ({ page }) => {
+    const fixture = await installRefreshFixture(page.context(), { refreshBehavior: 'timeout' })
+    const expiredUserMe = waitForUserMeResponse(page, 401)
+
+    await page.goto('/403', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(/\/login/, { timeout: 18_000 })
+    await assertUserMeResponse(await expiredUserMe, 401, `Bearer ${OLD_ACCESS_TOKEN}`)
+    expect(fixture.refreshCalls).toBe(1)
+    expect(fixture.userMeAttempts.length).toBeGreaterThanOrEqual(1)
+    expect(fixture.userMeAttempts.every((attempt) => (
+      attempt.authorization === `Bearer ${OLD_ACCESS_TOKEN}` && attempt.status === 401
+    ))).toBe(true)
+  })
+
+  test('自动刷新后退出登录使用最新 refresh token', async ({ page }) => {
+    const fixture = await installRefreshFixture(page.context())
+    let logoutBody: unknown = null
+
+    await page.route('**/api/v1/logout', async (route) => {
+      logoutBody = route.request().postDataJSON()
       await route.fulfill({
-        status: 401,
+        status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 401, message: 'access token expired' }),
+        body: JSON.stringify({ code: 200, message: 'logout success', data: null }),
       })
     })
-    await page.route('**/api/v1/refresh', async () => {
-      await new Promise((resolve) => setTimeout(resolve, 60_000))
-    })
 
-    await page.goto('/system/user')
-    await expect(page).toHaveURL(/\/login/, { timeout: 20_000 })
+    const expiredUserMe = waitForUserMeResponse(page, 401)
+    const successfulUserMe = waitForUserMeResponse(page, 200)
+    await page.goto('/403')
+    await assertUserMeResponse(await expiredUserMe, 401, `Bearer ${OLD_ACCESS_TOKEN}`)
+    await assertUserMeResponse(await successfulUserMe, 200, `Bearer ${NEW_ACCESS_TOKEN}`)
+
+    await page.locator('.app-user').click()
+    await page.getByRole('menuitem', { name: '退出登录' }).click()
+    await expect(page).toHaveURL(/\/login/)
+    expect(logoutBody).toEqual({ refresh_token: NEW_REFRESH_TOKEN })
+    expect(fixture.refreshCalls).toBe(1)
   })
 })

--- a/microservices/web/src/api/generated/schema.d.ts
+++ b/microservices/web/src/api/generated/schema.d.ts
@@ -287,7 +287,12 @@ export interface operations {
     };
   };
   "postApiV1MonitorJobLogsCleanup": {
-    requestBody: {
+    parameters: {
+      query: {
+        retention_days?: number;
+      };
+    };
+    requestBody?: {
       content: {
         "application/json": components["schemas"]["JobLogCleanupRequest"];
       };
@@ -309,7 +314,17 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -322,7 +337,7 @@ export interface operations {
         page?: number;
         page_size?: number;
         name?: string;
-        status?: number;
+        status?: 0 | 1;
       };
     };
     security: [{"BearerAuth":[]}];
@@ -342,7 +357,17 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -372,7 +397,17 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -402,7 +437,17 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -414,7 +459,7 @@ export interface operations {
     responses: {
       "200": {
         content: {
-          "application/json": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["JobHeartbeatsEnvelope"];
         };
       };
       "400": {
@@ -427,7 +472,17 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -457,7 +512,22 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "404": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -492,7 +562,22 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "404": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -522,7 +607,22 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "404": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -552,7 +652,22 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "404": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -582,7 +697,22 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "404": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -607,7 +737,17 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "503": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -628,6 +768,11 @@ export interface operations {
         };
       };
       "401": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "403": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -657,6 +802,11 @@ export interface operations {
           "application/json": components["schemas"]["ApiResponse"];
         };
       };
+      "403": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
       "500": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
@@ -669,7 +819,7 @@ export interface operations {
     responses: {
       "200": {
         content: {
-          "application/json": components["schemas"]["ApiResponse"];
+          "application/json": components["schemas"]["ServicesHealthEnvelope"];
         };
       };
       "400": {
@@ -678,6 +828,11 @@ export interface operations {
         };
       };
       "401": {
+        content: {
+          "application/json": components["schemas"]["ApiResponse"];
+        };
+      };
+      "403": {
         content: {
           "application/json": components["schemas"]["ApiResponse"];
         };
@@ -694,10 +849,10 @@ export interface operations {
 export interface components {
   schemas: {
     ApiResponse: {
-      code?: number;
+      code: number;
       data?: Record<string, unknown>;
       error_code?: string;
-      message?: string;
+      message: string;
     };
     EmptyEnvelope: {
       code: number;
@@ -734,6 +889,30 @@ export interface components {
       code: number;
       data: components["schemas"]["JobHealthCheck"];
       message: string;
+    };
+    JobHeartbeat: {
+      description: string;
+      fails: number;
+      id: number;
+      interval_sec: number;
+      job_key: string;
+      last_duration_ms: number;
+      last_error: string;
+      last_run_at: string;
+      last_status: string;
+      runs: number;
+      service: string;
+      stale: boolean;
+      updated_at: string;
+    };
+    JobHeartbeatsEnvelope: {
+      code: number;
+      data: components["schemas"]["JobHeartbeatsResponse"];
+      message: string;
+    };
+    JobHeartbeatsResponse: {
+      list: components["schemas"]["JobHeartbeat"][];
+      total: number;
     };
     JobListEnvelope: {
       code: number;
@@ -939,6 +1118,24 @@ export interface components {
       hostname: string;
       num_goroutine: number;
       platform: string;
+    };
+    ServiceHealthRow: {
+      error?: string;
+      http_code: number;
+      latency_ms: number;
+      name: string;
+      ok: boolean;
+    };
+    ServicesHealthEnvelope: {
+      code: number;
+      data: components["schemas"]["ServicesHealthResponse"];
+      message: string;
+    };
+    ServicesHealthResponse: {
+      checked_at: string;
+      healthy: number;
+      list: components["schemas"]["ServiceHealthRow"][];
+      total: number;
     };
   };
   securitySchemes: {

--- a/microservices/web/src/store/slices/authSlice.ts
+++ b/microservices/web/src/store/slices/authSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit'
 import { login as loginAPI, getCurrentUser, getUserMenus, logout as logoutAPI } from '@/api/auth'
-import { setTokens, clearTokens } from '@/utils/request'
+import { getRefreshToken, getToken, setTokens, clearTokens } from '@/utils/request'
 import type { LoginRequest, UserInfo, MenuItem } from '@/types'
 
 interface AuthState {
@@ -13,8 +13,8 @@ interface AuthState {
 }
 
 const initialState: AuthState = {
-  token: localStorage.getItem('access_token'),
-  refreshToken: localStorage.getItem('refresh_token'),
+  token: getToken(),
+  refreshToken: getRefreshToken(),
   userInfo: null,
   menus: [],
   permissions: [],
@@ -35,8 +35,10 @@ export const fetchCurrentUser = createAsyncThunk('auth/fetchCurrentUser', async 
 })
 
 export const logout = createAsyncThunk('auth/logout', async (_, { getState }) => {
+  // 自动刷新会更新统一存储，但 Redux 中的初始快照不会随之变化。
+  // 注销必须撤销当前轮换后的 refresh token。
   const state = getState() as { auth: AuthState }
-  const refreshToken = state.auth.refreshToken
+  const refreshToken = getRefreshToken() || state.auth.refreshToken
   try {
     if (refreshToken) await logoutAPI({ refresh_token: refreshToken })
   } finally {

--- a/microservices/web/src/utils/request.ts
+++ b/microservices/web/src/utils/request.ts
@@ -10,6 +10,9 @@ import { message } from './feedback'
 
 const TOKEN_KEY = 'access_token'
 const REFRESH_TOKEN_KEY = 'refresh_token'
+const AUTH_TOKEN_PAIR_KEY = 'auth_token_pair'
+const AUTH_TOKEN_PAIR_PENDING_KEY = 'auth_token_pair_pending'
+const AUTH_TOKEN_PAIR_PENDING_TTL_MS = 5_000
 const AUTH_TOKEN_CHANGE_KEY = 'auth_tokens_changed'
 const AUTH_TOKEN_CHANNEL = 'go-admin-kit-auth'
 const AUTH_REFRESH_LOCK_KEY = 'go-admin-kit-auth-refresh-lock'
@@ -38,7 +41,7 @@ type AuthRequestConfig = AxiosRequestConfig & {
 type AuthLockManager = {
   request<T>(
     name: string,
-    options: { ifAvailable?: boolean },
+    options: { ifAvailable?: boolean; signal?: AbortSignal },
     callback: (lock: object | null) => Promise<T>,
   ): Promise<T>
 }
@@ -52,11 +55,15 @@ type RefreshLeaseHandle = {
   backend: 'indexeddb' | 'storage'
 }
 
-type IndexedDBLeaseResult = 'acquired' | 'busy' | 'unavailable'
+type IndexedDBLeaseResult = 'acquired' | 'busy' | 'unsupported' | 'unavailable' | 'deadline-exceeded'
+
+type RefreshLockDatabaseResult =
+  | { status: 'available'; database: IDBDatabase }
+  | { status: 'unsupported' | 'unavailable' | 'deadline-exceeded' }
 
 const tabID = `${Date.now()}-${Math.random().toString(36).slice(2)}`
 let authChannel: BroadcastChannel | null | undefined
-let refreshLockDatabasePromise: Promise<IDBDatabase | null> | null = null
+let refreshLockDatabasePromise: Promise<RefreshLockDatabaseResult> | null = null
 
 function getAuthChannel() {
   if (authChannel !== undefined) return authChannel
@@ -70,6 +77,50 @@ function getAuthChannel() {
     authChannel = null
   }
   return authChannel
+}
+
+function readLegacyTokenPair(): TokenPair | null {
+  const access = localStorage.getItem(TOKEN_KEY)
+  const refresh = localStorage.getItem(REFRESH_TOKEN_KEY)
+  if (!access || !refresh) return null
+  return { access, refresh }
+}
+
+function hasActiveTokenPairWrite() {
+  const raw = localStorage.getItem(AUTH_TOKEN_PAIR_PENDING_KEY)
+  if (!raw) return false
+  const startedAt = Number(raw)
+  if (!Number.isFinite(startedAt) || Date.now() - startedAt > AUTH_TOKEN_PAIR_PENDING_TTL_MS) {
+    localStorage.removeItem(AUTH_TOKEN_PAIR_PENDING_KEY)
+    return false
+  }
+  return true
+}
+
+function readStoredTokenPair(): TokenPair | null {
+  const raw = localStorage.getItem(AUTH_TOKEN_PAIR_KEY)
+  let pair: TokenPair | null = null
+  if (raw) {
+    try {
+      const value = JSON.parse(raw) as Partial<TokenPair>
+      if (typeof value.access === 'string' && typeof value.refresh === 'string') {
+        pair = { access: value.access, refresh: value.refresh }
+      }
+    } catch {
+      pair = null
+    }
+  }
+
+  const legacy = readLegacyTokenPair()
+  if (!pair) return legacy
+  if (hasActiveTokenPairWrite()) return pair
+  if (legacy && (legacy.access !== pair.access || legacy.refresh !== pair.refresh)) {
+    // An older page only knows the two compatibility keys. Migrate its stable
+    // pair into the atomic snapshot before the next request reads it.
+    localStorage.setItem(AUTH_TOKEN_PAIR_KEY, JSON.stringify(legacy))
+    return legacy
+  }
+  return pair
 }
 
 function announceTokenChange() {
@@ -94,16 +145,38 @@ declare module 'axios' {
   }
 }
 
-export const getToken = () => localStorage.getItem(TOKEN_KEY)
-export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY)
+export const getToken = () => {
+  const pair = readStoredTokenPair()
+  return pair?.access || null
+}
+export const getRefreshToken = () => {
+  const pair = readStoredTokenPair()
+  return pair?.refresh || null
+}
 export const setTokens = (access: string, refresh: string) => {
-  localStorage.setItem(TOKEN_KEY, access)
-  localStorage.setItem(REFRESH_TOKEN_KEY, refresh)
+  localStorage.setItem(AUTH_TOKEN_PAIR_PENDING_KEY, String(Date.now()))
+  try {
+    // Keep legacy readers working while the single snapshot protects new
+    // readers from observing the two compatibility writes independently.
+    localStorage.setItem(TOKEN_KEY, access)
+    localStorage.setItem(REFRESH_TOKEN_KEY, refresh)
+    localStorage.setItem(AUTH_TOKEN_PAIR_KEY, JSON.stringify({ access, refresh }))
+  } finally {
+    localStorage.removeItem(AUTH_TOKEN_PAIR_PENDING_KEY)
+  }
   announceTokenChange()
 }
 export const clearTokens = () => {
-  localStorage.removeItem(TOKEN_KEY)
-  localStorage.removeItem(REFRESH_TOKEN_KEY)
+  localStorage.setItem(AUTH_TOKEN_PAIR_PENDING_KEY, String(Date.now()))
+  try {
+    // Commit the empty snapshot first so new readers stop using the session
+    // before the old compatibility keys are removed.
+    localStorage.setItem(AUTH_TOKEN_PAIR_KEY, JSON.stringify({ access: '', refresh: '' }))
+    localStorage.removeItem(TOKEN_KEY)
+    localStorage.removeItem(REFRESH_TOKEN_KEY)
+  } finally {
+    localStorage.removeItem(AUTH_TOKEN_PAIR_PENDING_KEY)
+  }
   announceTokenChange()
 }
 
@@ -112,10 +185,7 @@ NProgress.configure({ showSpinner: false })
 let refreshPromise: Promise<TokenPair> | null = null
 let loginRedirectStarted = false
 
-const readTokenPair = (): TokenPair => ({
-  access: getToken() || '',
-  refresh: getRefreshToken() || '',
-})
+const readTokenPair = (): TokenPair => readStoredTokenPair() || { access: '', refresh: '' }
 
 const hasUsableTokenPair = (pair: TokenPair) => Boolean(pair.access && pair.refresh)
 
@@ -148,16 +218,47 @@ function parseRefreshLease(value: string | null): RefreshLease | null {
   return normalizeRefreshLease(value)
 }
 
-function openRefreshLockDatabase(): Promise<IDBDatabase | null> {
-  if (refreshLockDatabasePromise) return refreshLockDatabasePromise
-  if (typeof indexedDB === 'undefined') return Promise.resolve(null)
+function invalidateRefreshLockDatabase(database?: IDBDatabase) {
+  refreshLockDatabasePromise = null
+  try {
+    database?.close()
+  } catch {
+    // The connection may already be closed.
+  }
+}
 
-  refreshLockDatabasePromise = new Promise((resolve) => {
+function openRefreshLockDatabase(deadline: number): Promise<RefreshLockDatabaseResult> {
+  if (refreshLockDatabasePromise) return refreshLockDatabasePromise
+  if (typeof indexedDB === 'undefined') return Promise.resolve({ status: 'unsupported' })
+
+  let promise: Promise<RefreshLockDatabaseResult> | undefined
+  let clearAfterCreation = false
+  const createdPromise = new Promise<RefreshLockDatabaseResult>((resolve) => {
+    let settled = false
+    let timer: number | undefined
+    const settleUnavailable = (status: 'unavailable' | 'deadline-exceeded') => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) window.clearTimeout(timer)
+      if (promise && refreshLockDatabasePromise === promise) refreshLockDatabasePromise = null
+      else clearAfterCreation = true
+      resolve({ status })
+    }
+    if (deadline <= Date.now()) {
+      settleUnavailable('deadline-exceeded')
+      return
+    }
+
     let request: IDBOpenDBRequest
     try {
       request = indexedDB.open(AUTH_REFRESH_DB_NAME, AUTH_REFRESH_DB_VERSION)
     } catch {
-      resolve(null)
+      settleUnavailable('unavailable')
+      return
+    }
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+      settleUnavailable('deadline-exceeded')
       return
     }
 
@@ -169,22 +270,50 @@ function openRefreshLockDatabase(): Promise<IDBDatabase | null> {
     }
     request.onsuccess = () => {
       const database = request.result
-      database.onversionchange = () => database.close()
-      resolve(database)
+      if (settled) {
+        database.close()
+        return
+      }
+      settled = true
+      if (timer !== undefined) window.clearTimeout(timer)
+      database.onversionchange = () => invalidateRefreshLockDatabase(database)
+      resolve({ status: 'available', database })
     }
-    request.onerror = () => resolve(null)
-    request.onblocked = () => resolve(null)
+    request.onerror = () => settleUnavailable('unavailable')
+    request.onblocked = () => settleUnavailable('unavailable')
+    timer = window.setTimeout(() => settleUnavailable('deadline-exceeded'), remaining)
   })
 
-  return refreshLockDatabasePromise
+  promise = createdPromise
+  refreshLockDatabasePromise = createdPromise
+  if (clearAfterCreation) refreshLockDatabasePromise = null
+  return createdPromise
 }
 
-async function tryAcquireIndexedDBLease(): Promise<IndexedDBLeaseResult> {
-  const database = await openRefreshLockDatabase()
-  if (!database) return 'unavailable'
+async function tryAcquireIndexedDBLease(deadline: number): Promise<IndexedDBLeaseResult> {
+  const databaseResult = await openRefreshLockDatabase(deadline)
+  if (databaseResult.status !== 'available') return databaseResult.status
+  const { database } = databaseResult
 
   return new Promise((resolve) => {
     let acquired = false
+    let settled = false
+    let timer: number | undefined
+    const finish = (result: IndexedDBLeaseResult) => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) window.clearTimeout(timer)
+      if (result === 'unavailable' || result === 'deadline-exceeded') {
+        invalidateRefreshLockDatabase(database)
+      }
+      resolve(result)
+    }
+
+    if (deadline <= Date.now()) {
+      finish('deadline-exceeded')
+      return
+    }
+
     try {
       const transaction = database.transaction(AUTH_REFRESH_DB_STORE, 'readwrite')
       const store = transaction.objectStore(AUTH_REFRESH_DB_STORE)
@@ -202,20 +331,42 @@ async function tryAcquireIndexedDBLease(): Promise<IndexedDBLeaseResult> {
         )
         acquired = true
       }
-      transaction.oncomplete = () => resolve(acquired ? 'acquired' : 'busy')
-      transaction.onerror = () => resolve('unavailable')
-      transaction.onabort = () => resolve('unavailable')
+      request.onerror = () => finish('unavailable')
+      transaction.oncomplete = () => finish(acquired ? 'acquired' : 'busy')
+      transaction.onerror = () => finish('unavailable')
+      transaction.onabort = () => finish('unavailable')
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) {
+        finish('deadline-exceeded')
+        return
+      }
+      timer = window.setTimeout(() => finish('deadline-exceeded'), remaining)
     } catch {
-      resolve('unavailable')
+      finish('unavailable')
     }
   })
 }
 
-async function releaseIndexedDBLease() {
-  const database = await openRefreshLockDatabase()
-  if (!database) return
+async function releaseIndexedDBLease(deadline: number) {
+  const databaseResult = await openRefreshLockDatabase(deadline)
+  if (databaseResult.status !== 'available') return
+  const { database } = databaseResult
 
   await new Promise<void>((resolve) => {
+    let settled = false
+    let timer: number | undefined
+    const finish = (invalidate = false) => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) window.clearTimeout(timer)
+      if (invalidate) invalidateRefreshLockDatabase(database)
+      resolve()
+    }
+    if (deadline <= Date.now()) {
+      finish(true)
+      return
+    }
+
     try {
       const transaction = database.transaction(AUTH_REFRESH_DB_STORE, 'readwrite')
       const store = transaction.objectStore(AUTH_REFRESH_DB_STORE)
@@ -224,11 +375,17 @@ async function releaseIndexedDBLease() {
         const current = normalizeRefreshLease(request.result)
         if (current?.owner === tabID) store.delete(AUTH_REFRESH_LOCK_KEY)
       }
-      transaction.oncomplete = () => resolve()
-      transaction.onerror = () => resolve()
-      transaction.onabort = () => resolve()
+      transaction.oncomplete = () => finish()
+      transaction.onerror = () => finish(true)
+      transaction.onabort = () => finish(true)
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) {
+        finish(true)
+        return
+      }
+      timer = window.setTimeout(() => finish(true), remaining)
     } catch {
-      resolve()
+      finish(true)
     }
   })
 }
@@ -250,19 +407,16 @@ function releaseStorageLease() {
   if (current?.owner === tabID) localStorage.removeItem(AUTH_REFRESH_LOCK_KEY)
 }
 
-async function acquireRefreshLease(): Promise<RefreshLeaseHandle | null> {
-  const indexedDBResult = await tryAcquireIndexedDBLease()
+async function acquireRefreshLease(deadline: number): Promise<RefreshLeaseHandle | null> {
+  const indexedDBResult = await tryAcquireIndexedDBLease(deadline)
   if (indexedDBResult === 'acquired') return { backend: 'indexeddb' }
-  if (indexedDBResult === 'busy') return null
-  // IndexedDB is the strict fallback. Only browsers that cannot open it use
-  // the legacy best-effort lease; a losing 401 waits for the winner's token
-  // announcement before the caller treats refresh as a real failure.
+  if (indexedDBResult !== 'unsupported') return null
   return tryAcquireStorageLease() ? { backend: 'storage' } : null
 }
 
-async function releaseRefreshLease(handle: RefreshLeaseHandle) {
+async function releaseRefreshLease(handle: RefreshLeaseHandle, deadline: number) {
   if (handle.backend === 'indexeddb') {
-    await releaseIndexedDBLease()
+    await releaseIndexedDBLease(deadline)
     return
   }
   releaseStorageLease()
@@ -307,12 +461,15 @@ function waitForTokenPairUpdate(previous: TokenPair, timeoutMs: number): Promise
   })
 }
 
-async function requestFreshTokenPair(used: TokenPair): Promise<TokenPair> {
+async function requestFreshTokenPair(used: TokenPair, deadline: number): Promise<TokenPair> {
   try {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) throw new Error('refresh deadline exceeded')
+
     const res = await axios.post(
       '/api/v1/refresh',
       { refresh_token: used.refresh },
-      { timeout: AUTH_REFRESH_REQUEST_TIMEOUT_MS },
+      { timeout: Math.min(AUTH_REFRESH_REQUEST_TIMEOUT_MS, remaining) },
     )
     const payload = res.data?.data ?? res.data
     const access = payload?.access_token
@@ -323,6 +480,7 @@ async function requestFreshTokenPair(used: TokenPair): Promise<TokenPair> {
 
     // Do not overwrite a newer login/refresh that completed while this request
     // was in flight. The newer pair is already the source of truth.
+    if (Date.now() >= deadline) throw new Error('refresh deadline exceeded')
     const current = readTokenPair()
     if (!sameTokenPair(current, used)) {
       if (hasUsableTokenPair(current)) return current
@@ -340,7 +498,11 @@ async function requestFreshTokenPair(used: TokenPair): Promise<TokenPair> {
     // the 401 as a real authentication failure.
     const status = (error as { response?: { status?: number } })?.response?.status
     if (status === 401) {
-      const updated = await waitForTokenPairUpdate(used, AUTH_REFRESH_RECOVERY_WAIT_MS)
+      const remaining = Math.max(0, deadline - Date.now())
+      const updated = await waitForTokenPairUpdate(
+        used,
+        Math.min(AUTH_REFRESH_RECOVERY_WAIT_MS, remaining),
+      )
       if (updated) return updated
     }
     throw error
@@ -351,60 +513,113 @@ function sameTokenPair(left: TokenPair, right: TokenPair) {
   return left.access === right.access && left.refresh === right.refresh
 }
 
-async function refreshWithStorageLease(previous: TokenPair): Promise<TokenPair> {
-  const deadline = Date.now() + AUTH_REFRESH_WAIT_MS
+async function refreshWithStorageLease(previous: TokenPair, deadline: number): Promise<TokenPair> {
   while (Date.now() < deadline) {
     const current = readTokenPair()
     if (tokenPairChanged(current, previous)) return current
     if (!hasUsableTokenPair(current)) throw new Error('refresh token is missing')
 
-    const lease = await acquireRefreshLease()
+    const lease = await acquireRefreshLease(deadline)
     if (lease) {
       try {
         const latest = readTokenPair()
         if (tokenPairChanged(latest, previous)) return latest
-        return await requestFreshTokenPair(latest)
+        return await requestFreshTokenPair(latest, deadline)
       } finally {
-        await releaseRefreshLease(lease)
+        await releaseRefreshLease(lease, deadline)
       }
     }
 
-    const updated = await waitForTokenPairUpdate(previous, Math.min(500, deadline - Date.now()))
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) break
+    const updated = await waitForTokenPairUpdate(previous, Math.min(500, remaining))
     if (updated) return updated
   }
   throw new Error('timed out waiting for another page to refresh the session')
 }
 
+type WebLockCallbackResult<T> =
+  | { type: 'completed'; value: T }
+  | { type: 'callback-error'; error: unknown }
+
+type WebLockRequestResult<T> =
+  | WebLockCallbackResult<T>
+  | { type: 'api-error'; error: unknown }
+  | { type: 'deadline-exceeded' }
+
+async function requestWebLock<T>(
+  locks: AuthLockManager,
+  callback: (lock: object | null) => Promise<T>,
+  deadline: number,
+): Promise<WebLockRequestResult<T>> {
+  if (deadline <= Date.now()) return { type: 'deadline-exceeded' }
+
+  const controller = typeof AbortController === 'undefined' ? null : new AbortController()
+  let timer: number | undefined
+  try {
+    const request = locks.request<WebLockCallbackResult<T>>(
+      AUTH_REFRESH_LOCK_NAME,
+      { ifAvailable: true, ...(controller ? { signal: controller.signal } : {}) },
+      async (lock) => {
+        try {
+          return { type: 'completed', value: await callback(lock) }
+        } catch (error) {
+          return { type: 'callback-error', error }
+        }
+      },
+    )
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+      controller?.abort()
+      return { type: 'deadline-exceeded' }
+    }
+    return await Promise.race([
+      request,
+      new Promise<{ type: 'deadline-exceeded' }>((resolve) => {
+        timer = window.setTimeout(() => {
+          controller?.abort()
+          resolve({ type: 'deadline-exceeded' })
+        }, remaining)
+      }),
+    ])
+  } catch (error) {
+    return { type: 'api-error', error }
+  } finally {
+    if (timer !== undefined) window.clearTimeout(timer)
+  }
+}
+
 async function refreshAcrossContexts(previous: TokenPair): Promise<TokenPair> {
+  const deadline = Date.now() + AUTH_REFRESH_WAIT_MS
   const locks = getWebLockManager()
   if (locks) {
-    const deadline = Date.now() + AUTH_REFRESH_WAIT_MS
     while (Date.now() < deadline) {
-      const refreshed = await locks.request<TokenPair | null>(
-        AUTH_REFRESH_LOCK_NAME,
-        { ifAvailable: true },
-        async (lock) => {
+      const result = await requestWebLock(locks, async (lock) => {
           if (!lock) return null
           const current = readTokenPair()
           if (tokenPairChanged(current, previous)) return current
           if (!hasUsableTokenPair(current)) throw new Error('refresh token is missing')
-          return requestFreshTokenPair(current)
-        },
-      )
-      if (refreshed) return refreshed
+          return requestFreshTokenPair(current, deadline)
+        }, deadline)
+      if (result.type === 'api-error') return refreshWithStorageLease(previous, deadline)
+      if (result.type === 'deadline-exceeded') throw new Error('timed out waiting for another page to refresh the session')
+      if (result.type === 'callback-error') throw result.error
+      if (result.value) return result.value
 
-      const updated = await waitForTokenPairUpdate(previous, Math.min(500, deadline - Date.now()))
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) break
+      const updated = await waitForTokenPairUpdate(previous, Math.min(500, remaining))
       if (updated) return updated
     }
     throw new Error('timed out waiting for another page to refresh the session')
   }
-  return refreshWithStorageLease(previous)
+  return refreshWithStorageLease(previous, deadline)
 }
 
 function refreshTokenPair(previous: TokenPair): Promise<TokenPair> {
+  if (refreshPromise) return refreshPromise
   const current = readTokenPair()
   if (tokenPairChanged(current, previous)) return Promise.resolve(current)
-  if (refreshPromise) return refreshPromise
 
   const next = refreshAcrossContexts(previous)
   refreshPromise = next
@@ -434,10 +649,11 @@ const instance: AxiosInstance = axios.create({
 
 instance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   NProgress.start()
-  const token = getToken()
+  const storedPair = readTokenPair()
+  const token = storedPair.access || null
   const authConfig = config as InternalAxiosRequestConfig & AuthRequestConfig
-  authConfig._authAccessToken = token || ''
-  authConfig._authRefreshToken = getRefreshToken() || ''
+  authConfig._authAccessToken = storedPair.access
+  authConfig._authRefreshToken = storedPair.refresh
   if (token) {
     config.headers.Authorization = `Bearer ${token}`
   }


### PR DESCRIPTION
## 变更说明

本 PR 面向 `v0.2.0-rc.2` 候选版，范围为微服务认证刷新协调与 monitor OpenAPI 契约。

- 刷新后的注销读取当前 refresh token，避免撤销旧 token。
- 为 Web Locks 与 IndexedDB 协调增加统一 deadline、异常恢复和滚动发布兼容。
- 补齐 monitor cleanup 参数约束、可选请求体类型和生成契约检查。
- 增加跨页面、跨版本及存储操作不结束场景的 Playwright 回归。

## 变更类型

- [x] Bug 修复
- [x] 测试补充
- [x] 工程配置或依赖更新

## 验证

- [x] `cd services/monitor && go test ./... && go vet ./...`
- [x] `cd web && npm run lint && npm run build`（lint 仅有仓库既有 warning）
- [x] `npm run api:contract`
- [x] `npm run test:contract`（4/4）
- [x] `npm run test:smoke:unit`（7/7）
- [x] CI 生产依赖审计门禁：仅对已审查的 `GHSA-qwww-vcr4-c8h2` 做显式临时 allowlist，其他 advisory 仍失败。
- [x] GitHub CI 运行 `30144833020`：9/9 job 通过，包含 API smoke 与 Playwright E2E。

## 数据库、配置和安全影响

- 不涉及数据库迁移、配置项、权限码或菜单种子。
- 认证刷新流程属于安全边界修复，兼容旧版本页面和现有 token 存储。
- 上游尚未发布修复 `react-router` 当前 RSC 专项高危公告的安全版本；本项目使用 `BrowserRouter`，CI 已保留显式告警和 allowlist，后续应移除该例外。

## 边界确认

- [x] 未引入 monolith 与 microservices 的业务依赖或互相调用。

## 截图

无 UI 变更，无需截图。